### PR TITLE
Replace deprecated include keyword with import_tasks

### DIFF
--- a/roles/bin/tasks/main.yml
+++ b/roles/bin/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-- include: bin.yml
+- import_tasks: bin.yml
   tags: bin

--- a/roles/directories/tasks/main.yml
+++ b/roles/directories/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-- include: directories.yml
+- import_tasks: directories.yml
   tags: directories

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
-- include: fedora.yml
+- import_tasks: fedora.yml
   tags: docker
   when: ansible_os_family == 'RedHat'

--- a/roles/dotfiles/tasks/main.yml
+++ b/roles/dotfiles/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-- include: dotfiles.yml
+- import_tasks: dotfiles.yml
   tags: dotfiles


### PR DESCRIPTION
Docs: https://docs.ansible.com/ansible-core/2.12/user_guide/playbooks_reuse.html#re-using-files-and-roles

Address this message:

[DEPRECATION WARNING]: "include" is deprecated, use include_tasks/import_tasks 
instead. This feature will be removed in version 2.16. Deprecation warnings can
 be disabled by setting deprecation_warnings=False in ansible.cfg.
