### PR TITLE
Upgrade jdk 17 -> 21

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["quay.io/centos/centos:stream9", "almalinux:latest"]
+        # Remove "quay.io/centos/centos:stream9" for now as
+        # CS9 has no jdk-21 package despite it's available in EL9
+        # https://forums.centos.org/viewtopic.php?t=80650
+        version: ["almalinux:latest"]
     steps:
       - uses: actions/checkout@v4
       - name: Build Test Container EL ${{ matrix.version }}

--- a/debug/Dockerfile.debian
+++ b/debug/Dockerfile.debian
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
   python3-pip \
   ansible \
   unzip \
-  libasound2 \
+  libasound2t64 \
   && mkdir -p /home/user \
   && echo "user:x:1001:1001:user:/home/user:/bin/bash" >> /etc/passwd \
   && echo "user:x:1001:" >> /etc/group \

--- a/debug/Dockerfile.ubuntu
+++ b/debug/Dockerfile.ubuntu
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
   python3-pip \
   ansible \
   unzip \
-  libasound2 \
+  libasound2t64 \
   && mkdir -p /home/user \
   && echo "user:x:1001:1001:user:/home/user:/bin/bash" >> /etc/passwd \
   && echo "user:x:1001:" >> /etc/group \

--- a/default.config.yml
+++ b/default.config.yml
@@ -104,7 +104,7 @@ development_packages:
   RedHat:
     - cargo
     - golang
-    - java-17-openjdk-devel
+    - java-21-openjdk-devel
     - maven
     - nodejs
     - npm
@@ -112,7 +112,7 @@ development_packages:
   Suse:
     - cargo
     - go
-    - java-17-openjdk-devel
+    - java-21-openjdk-devel
     - maven
     - nodejs-default
     - npm-default

--- a/test/container/Containerfile.dpkg
+++ b/test/container/Containerfile.dpkg
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y \
   python3-pip \
   python3-distro \
   unzip \
-  libasound2 \
+  libasound2t64 \
   && mkdir -p /home/user \
   && echo "user:x:1001:1001:user:/home/user:/bin/bash" >> /etc/passwd \
   && echo "user:x:1001:" >> /etc/group \


### PR DESCRIPTION
Remove "quay.io/centos/centos:stream9" for now as
CS9 has no jdk-21 package despite it's available in EL9
https://forums.centos.org/viewtopic.php?t=80650