### PR TITLE
fix apt-key issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,14 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          ["ubuntu:latest", "ubuntu:rolling", "ubuntu:devel", "debian:testing"]
+          [
+            "ubuntu:latest",
+            "ubuntu:rolling",
+            "ubuntu:devel",
+            "debian:stable",
+            "debian:testing",
+            "debian:unstable",
+          ]
     steps:
       - uses: actions/checkout@v4
       - name: Build Test Container deb ${{ matrix.version }}
@@ -37,8 +44,8 @@ jobs:
       - name: Run Test Fedora ${{ matrix.version }}
         run: docker run --user user --tty --volume $PWD:/mnt system-automation-test-fedora-${{ matrix.version }}
 
-# deb822_repository is new in ansible-core 2.15
-# which is not (yet?) available for EL9
+  # deb822_repository is new in ansible-core 2.15
+  # which is not (yet?) available for EL9
   # el:
   #   runs-on: ubuntu-22.04
   #   strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,21 +37,23 @@ jobs:
       - name: Run Test Fedora ${{ matrix.version }}
         run: docker run --user user --tty --volume $PWD:/mnt system-automation-test-fedora-${{ matrix.version }}
 
-  el:
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        # Remove "quay.io/centos/centos:stream9" for now as
-        # CS9 has no jdk-21 package despite it's available in EL9
-        # https://forums.centos.org/viewtopic.php?t=80650
-        version: ["almalinux:latest"]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build Test Container EL ${{ matrix.version }}
-        run: docker build --build-arg=VERSION=${{ matrix.version }} -t system-automation-test-el-${{ matrix.version }} --file test/container/Containerfile.el .
-      - name: Run Test EL ${{ matrix.version }}
-        run: docker run --user user --tty --volume $PWD:/mnt system-automation-test-el-${{ matrix.version }}
+# deb822_repository is new in ansible-core 2.15
+# which is not (yet?) available for EL9
+  # el:
+  #   runs-on: ubuntu-22.04
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       # Remove "quay.io/centos/centos:stream9" for now as
+  #       # CS9 has no jdk-21 package despite it's available in EL9
+  #       # https://forums.centos.org/viewtopic.php?t=80650
+  #       version: ["almalinux:latest"]
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Build Test Container EL ${{ matrix.version }}
+  #       run: docker build --build-arg=VERSION=${{ matrix.version }} -t system-automation-test-el-${{ matrix.version }} --file test/container/Containerfile.el .
+  #     - name: Run Test EL ${{ matrix.version }}
+  #       run: docker run --user user --tty --volume $PWD:/mnt system-automation-test-el-${{ matrix.version }}
 
   zypper:
     runs-on: ubuntu-22.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,12 +15,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version:
-          [
+        version: [
             "ubuntu:latest",
             "ubuntu:rolling",
             "ubuntu:devel",
-            "debian:stable",
+            # deb822_repository is new in ansible-core 2.15
+            # which is not (yet?) available for bookworm
+            # "debian:stable",
             "debian:testing",
             "debian:unstable",
           ]

--- a/roles/docker/tasks/deb.yml
+++ b/roles/docker/tasks/deb.yml
@@ -65,6 +65,7 @@
   ansible.builtin.apt:
     state: present
     name: "{{ item }}"
+    update_cache: yes
   loop:
     - docker-ce
     - docker-ce-cli

--- a/roles/docker/tasks/deb.yml
+++ b/roles/docker/tasks/deb.yml
@@ -30,15 +30,6 @@
     - lsb-release
   become: true
 
-- name: Add Docker apt key
-  ansible.builtin.shell: |
-    set -o pipefail
-    curl -sSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-  args:
-    executable: /bin/bash
-  changed_when: false
-  become: true
-
 # Special handling because Docker provides no packages for Ubuntu's development branch
 - name: Get Ubuntu codename
   ansible.builtin.set_fact:
@@ -59,11 +50,14 @@
       Ansible Distribution: {{ansible_distribution|lower}}
 
 - name: Add Docker APT repository
-  ansible.builtin.apt_repository:
-    repo: "deb https://download.docker.com/linux/{{ansible_distribution|lower}}   {{ deb_release_codename }} stable"
+  ansible.builtin.deb822_repository:
+    name: docker
+    types: [deb]
+    uris: "https://download.docker.com/linux/{{ansible_distribution|lower}}"
+    components: [{{ deb_release_codename }}, stable]
+    signed_by: https://download.docker.com/linux/ubuntu/gpg
     state: present
-    update_cache: true
-  become: true
+    enabled: true
 
 - name: Install Docker Engine
   ansible.builtin.apt:

--- a/roles/docker/tasks/deb.yml
+++ b/roles/docker/tasks/deb.yml
@@ -54,10 +54,12 @@
     name: docker
     types: [deb]
     uris: "https://download.docker.com/linux/{{ansible_distribution|lower}}"
-    components: [{{ deb_release_codename }}, stable]
+    suites: "{{ deb_release_codename }}"
+    components: [stable]
     signed_by: https://download.docker.com/linux/ubuntu/gpg
     state: present
     enabled: true
+  become: true
 
 - name: Install Docker Engine
   ansible.builtin.apt:

--- a/roles/greenleader.codium/tasks/main.yml
+++ b/roles/greenleader.codium/tasks/main.yml
@@ -34,6 +34,8 @@
     signed_by: https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.gpg
     state: present
     enabled: true
+  when:
+    - ansible_os_family == 'Debian'
 
 - name: Ensure codium is installed
   ansible.builtin.package:

--- a/roles/greenleader.codium/tasks/main.yml
+++ b/roles/greenleader.codium/tasks/main.yml
@@ -24,24 +24,19 @@
   when:
     - ansible_os_family == 'RedHat'
 
-- name: Ensure GPG key for repo is installed (Debian)
-  ansible.builtin.apt_key:
-    url: https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.gpg
-    id: "{{ gpg_fingerprint }}"
-    state: present
-  when:
-    - ansible_os_family == 'Debian'
-
 - name: Ensure repo is installed (Debian)
-  ansible.builtin.apt_repository:
-    repo: "deb https://paulcarroty.gitlab.io/vscodium-deb-rpm-repo/debs/ vscodium main"
-    filename: codium
+  ansible.builtin.deb822_repository:
+    name: codium
+    types: [deb]
+    uris: "https://paulcarroty.gitlab.io/vscodium-deb-rpm-repo/debs/"
+    suites: vscodium
+    components: [main]
+    signed_by: https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.gpg
     state: present
-    update_cache: true
-  when:
-    - ansible_os_family == 'Debian'
+    enabled: true
 
 - name: Ensure codium is installed
   ansible.builtin.package:
     name: codium
     state: present
+    update_cache: yes

--- a/roles/iesplin.vscode/tasks/main.yml
+++ b/roles/iesplin.vscode/tasks/main.yml
@@ -14,3 +14,4 @@
   package:
     name: code
     state: present
+    update_cache: yes

--- a/roles/iesplin.vscode/tasks/setup-debian-repo.yml
+++ b/roles/iesplin.vscode/tasks/setup-debian-repo.yml
@@ -10,13 +10,12 @@
     state: present
     update_cache: true
 
-- name: Add Microsoft signing key
-  apt_key:
-    url: https://packages.microsoft.com/keys/microsoft.asc
-    state: present
-
 - name: Add Microsoft repository
-  apt_repository:
-    repo: deb [arch=amd64] https://packages.microsoft.com/repos/vscode stable main
+  ansible.builtin.deb822_repository:
+    name: vscode
+    types: [deb]
+    uris: "https://packages.microsoft.com/repos/vscode"
+    components: [stable, main]
+    signed_by: https://packages.microsoft.com/keys/microsoft.asc
     state: present
-    filename: vscode
+    enabled: true

--- a/roles/iesplin.vscode/tasks/setup-debian-repo.yml
+++ b/roles/iesplin.vscode/tasks/setup-debian-repo.yml
@@ -15,7 +15,8 @@
     name: vscode
     types: [deb]
     uris: "https://packages.microsoft.com/repos/vscode"
-    components: [stable, main]
+    suites: stable
+    components: [main]
     signed_by: https://packages.microsoft.com/keys/microsoft.asc
     state: present
     enabled: true

--- a/test/container/Containerfile.dpkg
+++ b/test/container/Containerfile.dpkg
@@ -16,7 +16,6 @@ RUN apt-get update && apt-get install -y \
   python3-pip \
   python3-distro \
   unzip \
-  libasound2t64 \
   && mkdir -p /home/user \
   && echo "user:x:1001:1001:user:/home/user:/bin/bash" >> /etc/passwd \
   && echo "user:x:1001:" >> /etc/group \


### PR DESCRIPTION
This change is incompatible with older ansible versions (ansible-core < 2.15), but required for newer debian/ubuntu versions (trixie and later).

For the time being, I'll keep a branch that works with debian bookworm [here](https://github.com/fwilhe2/system-automation/tree/maint-ansible-2.14).

More info on apt-key and how to replace it:

https://askubuntu.com/a/1307181

https://www.jeffgeerling.com/blog/2022/aptkey-deprecated-debianubuntu-how-fix-ansible