### PR TITLE
fix: correct 'Redhat' typo so system development packages install on RedHat family

### DIFF
--- a/roles/development/tasks/main.yml
+++ b/roles/development/tasks/main.yml
@@ -19,7 +19,7 @@
     name: "{{ item }}"
   loop: "{{ system_development_packages[ansible_os_family] }}"
   tags: development
-  when: ansible_os_family == 'Debian' or ansible_os_family == 'Redhat'
+  when: ansible_os_family == 'Debian' or ansible_os_family == 'RedHat'
 
 - name: Install System Development Packages (Suse)
   become: true


### PR DESCRIPTION
## Summary
- `roles/development/tasks/main.yml` compared `ansible_os_family` against `'Redhat'`, but the fact value is `'RedHat'` (capital H).
- As a result, the "Install System Development Packages" task (`@C Development Tools and Libraries`, `cmake`) was silently skipped on Fedora/EL — invisible in CI because a skipped task looks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)