### PR TITLE
ci: syntax-check all playbooks instead of desktop.yml twice

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,8 +91,10 @@ jobs:
         with:
           python-version: "3.x"
       - run: pip3 install ansible
-      - run: ansible-playbook -vvvv --inventory inventory --syntax-check desktop.yml
-      - run: ansible-playbook -vvvv --inventory inventory --syntax-check desktop.yml
+      - run: |
+          for playbook in common.yml desktop.yml minimal.yml dev-env.yml vm-host.yml epel.yml snap.yml clone-git-repos.yml; do
+            ansible-playbook --inventory inventory --syntax-check "$playbook"
+          done
 
   # Check fails for unknown reasons, files are formatted locally
   # formatting:


### PR DESCRIPTION
## Summary
- The `syntax-check` job contained a copy-paste duplicate: it checked `desktop.yml` twice and nothing else.
- Now loops over all eight playbooks (`common`, `desktop`, `minimal`, `dev-env`, `vm-host`, `epel`, `snap`, `clone-git-repos`).
- Dropped `-vvvv` since eight verbose runs make the log unreadable; syntax errors are reported fine without it.

## Test plan
- Ran the same loop locally with ansible-core 2.19: all eight playbooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)