### PR TITLE
fix: migrate to ansible_facts before ansible-core 2.24

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ Tag a task `notest` to have CI skip it (`--skip-tags notest`); currently only fl
   comments, put the tags in a Jinja comment in the `.j2` template or add a `.license`
   sidecar; `.reuse/dep5` covers the exceptions.
 - YAML is prettier-formatted. `.j2` templates are not.
-- Facts are used in the `ansible_os_family` / `ansible_architecture` style throughout, which
-  ansible-core deprecates in favour of `ansible_facts[...]`. Match the surrounding style
-  rather than migrating one file.
+- Facts are referenced as `ansible_facts['os_family']`, never as top-level `ansible_*`
+  variables, which ansible-core 2.24 removes. Single quotes inside the brackets: the
+  double-quoted form nests badly inside double-quoted YAML scalars. `ansible_version` and
+  `ansible_managed` are magic variables rather than facts and keep their names.

--- a/README.adoc
+++ b/README.adoc
@@ -136,7 +136,8 @@ Free use of this software is granted under the terms of the MIT License.
 
 === Copyright Notice
 
-This project ships the following 3rd party software:
+This project ships the following 3rd party software.
+The copies below have been modified, so they do not match their upstream projects:
 
 https://github.com/green-leader/ansible-role-codium[ansible-role-codium] (`roles/greenleader.codium`)::
   Copyright © Sion Fandrick under the _MIT License_

--- a/desktop.yml
+++ b/desktop.yml
@@ -15,8 +15,8 @@
     - role: iesplin.vscode
       become: true
       when: >-
-        ansible_distribution != 'openSUSE Tumbleweed'
-        and not (ansible_distribution == 'Debian' and ansible_architecture == 'aarch64')
+        ansible_facts['distribution'] != 'openSUSE Tumbleweed'
+        and not (ansible_facts['distribution'] == 'Debian' and ansible_facts['architecture'] == 'aarch64')
 
     - role: greenleader.codium
       become: true
@@ -37,7 +37,7 @@
       ansible.builtin.package:
         state: present
         name: "{{ item }}"
-      loop: "{{ desktop_packages[ansible_os_family] }}"
+      loop: "{{ desktop_packages[ansible_facts['os_family']] }}"
 
     - name: Install VS Codium Extensions
       codium-extensions:

--- a/epel.yml
+++ b/epel.yml
@@ -7,8 +7,8 @@
 
   tasks:
     - when:
-        - "ansible_os_family == 'RedHat'"
-        - "ansible_distribution != 'Fedora'"
+        - "ansible_facts['os_family'] == 'RedHat'"
+        - "ansible_facts['distribution'] != 'Fedora'"
       block:
         - name: Enable EPEL
           ansible.builtin.include_role:
@@ -16,12 +16,12 @@
 
         - name: Enable EPEL Next
           when:
-            - "ansible_distribution == 'CentOS'"
-            - "ansible_distribution_release == 'Stream'"
+            - "ansible_facts['distribution'] == 'CentOS'"
+            - "ansible_facts['distribution_release'] == 'Stream'"
           ansible.builtin.include_role:
             name: gotmax23.epel.epel_next
 
         - name: Enable CRB
-          when: ansible_distribution_major_version | int >= 8
+          when: ansible_facts['distribution_major_version'] | int >= 8
           ansible.builtin.include_role:
             name: gotmax23.epel.crb

--- a/roles/basic/tasks/main.yml
+++ b/roles/basic/tasks/main.yml
@@ -8,7 +8,7 @@
   ansible.builtin.package:
     state: present
     name: "{{ item }}"
-  loop: "{{ basic_packages[ansible_os_family] }}"
+  loop: "{{ basic_packages[ansible_facts['os_family']] }}"
   tags: basic
   ignore_errors: true
 
@@ -17,7 +17,7 @@
   community.general.alternatives:
     name: editor
     path: /usr/bin/vim
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts['os_family'] == 'Debian'
   tags: basic
 
 - name: Configure user

--- a/roles/bodsch.ansible-snapd/tasks/main.yml
+++ b/roles/bodsch.ansible-snapd/tasks/main.yml
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: Bodo Schulz
+# SPDX-FileCopyrightText: Florian Wilhelm
 # SPDX-License-Identifier: BSD-2-Clause
 
 ---
 
 - name: run only for debian based
   when:
-    - ansible_os_family | lower != "debian"
+    - ansible_facts['os_family'] | lower != "debian"
   block:
     - name: message
       ansible.builtin.debug:
@@ -70,7 +71,7 @@
 
     - name: find nap mountpoints
       ansible.builtin.set_fact:
-        snap_mounts: "{{ ansible_mounts | snap_mounts }}"
+        snap_mounts: "{{ ansible_facts['mounts'] | snap_mounts }}"
 
     - name: unmount snap
       become: true

--- a/roles/development/tasks/main.yml
+++ b/roles/development/tasks/main.yml
@@ -8,7 +8,7 @@
   ansible.builtin.package:
     state: present
     name: "{{ item }}"
-  loop: "{{ development_packages[ansible_os_family] }}"
+  loop: "{{ development_packages[ansible_facts['os_family']] }}"
   tags: development
 
 - name: Install System Development Packages
@@ -17,9 +17,9 @@
   ansible.builtin.package:
     state: present
     name: "{{ item }}"
-  loop: "{{ system_development_packages[ansible_distribution] | default(system_development_packages[ansible_os_family]) }}"
+  loop: "{{ system_development_packages[ansible_facts['distribution']] | default(system_development_packages[ansible_facts['os_family']]) }}"
   tags: development
-  when: ansible_os_family == 'Debian' or ansible_os_family == 'RedHat'
+  when: ansible_facts['os_family'] == 'Debian' or ansible_facts['os_family'] == 'RedHat'
 
 - name: Install System Development Packages (Suse)
   become: true
@@ -29,4 +29,4 @@
     name: devel_basis
     type: pattern
   tags: development
-  when: ansible_os_family == 'Suse'
+  when: ansible_facts['os_family'] == 'Suse'

--- a/roles/docker/tasks/deb.yml
+++ b/roles/docker/tasks/deb.yml
@@ -33,27 +33,27 @@
 # Special handling because Docker provides no packages for Ubuntu's development branch
 - name: Get Ubuntu codename
   ansible.builtin.set_fact:
-    deb_release_codename: "{{ 'jammy' if ansible_lsb.description is search('development branch', ignorecase=True) else ansible_distribution_release }}"
-  when: ansible_distribution == 'Ubuntu'
+    deb_release_codename: "{{ 'jammy' if ansible_facts['lsb'].description is search('development branch', ignorecase=True) else ansible_facts['distribution_release'] }}"
+  when: ansible_facts['distribution'] == 'Ubuntu'
 
 # Special handling because Docker provides no packages for Debian Trixie as of now
 - name: Get Debian codename
   ansible.builtin.set_fact:
-    deb_release_codename: "{{ 'trixie' if ansible_lsb.description is search('sid', ignorecase=True) else ansible_distribution_release }}"
-  when: ansible_distribution == 'Debian'
+    deb_release_codename: "{{ 'trixie' if ansible_facts['lsb'].description is search('sid', ignorecase=True) else ansible_facts['distribution_release'] }}"
+  when: ansible_facts['distribution'] == 'Debian'
 
 - name: dbg
   ansible.builtin.debug:
     msg: |
       Debian codename for Docker apt repo: {{ deb_release_codename }}
-      Actual ansible_distribution_release: {{ ansible_distribution_release }} ({{ ansible_lsb.description }})
-      Ansible Distribution: {{ansible_distribution|lower}}
+      Actual ansible_facts['distribution_release']: {{ ansible_facts['distribution_release'] }} ({{ ansible_facts['lsb'].description }})
+      Ansible Distribution: {{ansible_facts['distribution']|lower}}
 
 - name: Add Docker APT repository
   ansible.builtin.deb822_repository:
     name: docker
     types: [deb]
-    uris: "https://download.docker.com/linux/{{ansible_distribution|lower}}"
+    uris: "https://download.docker.com/linux/{{ansible_facts['distribution']|lower}}"
     suites: "{{ deb_release_codename }}"
     components: [stable]
     signed_by: https://download.docker.com/linux/ubuntu/gpg
@@ -101,4 +101,4 @@
     - podman
   become: true
   # TODO: Update once focal is not required anymore
-  when: ansible_distribution_release != "focal"
+  when: ansible_facts['distribution_release'] != "focal"

--- a/roles/docker/tasks/el.yml
+++ b/roles/docker/tasks/el.yml
@@ -7,4 +7,4 @@
     name: podman
     state: present
   become: true
-  when: ansible_os_family == 'RedHat' and ansible_distribution != 'Fedora'
+  when: ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution'] != 'Fedora'

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -4,16 +4,16 @@
 ---
 - import_tasks: fedora.yml
   tags: docker
-  when: ansible_os_family == 'RedHat' and ansible_distribution == 'Fedora'
+  when: ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution'] == 'Fedora'
 
 - import_tasks: el.yml
   tags: docker
-  when: ansible_os_family == 'RedHat' and ansible_distribution != 'Fedora'
+  when: ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution'] != 'Fedora'
 
 - import_tasks: deb.yml
   tags: docker
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts['os_family'] == 'Debian'
 
 - import_tasks: suse.yml
   tags: docker
-  when: ansible_os_family == 'Suse'
+  when: ansible_facts['os_family'] == 'Suse'

--- a/roles/docker/tasks/suse.yml
+++ b/roles/docker/tasks/suse.yml
@@ -9,4 +9,4 @@
   community.general.zypper:
     state: present
     name: podman
-  when: ansible_os_family == 'Suse'
+  when: ansible_facts['os_family'] == 'Suse'

--- a/roles/dotfiles/tasks/dotfiles.yml
+++ b/roles/dotfiles/tasks/dotfiles.yml
@@ -28,28 +28,28 @@
     src: files/dnf-aliases.txt
     dest: ~/.dotfiles/aliases_package_manager
     mode: "640"
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts['os_family'] == 'RedHat'
 
 - name: Copy Package Manager Aliases File
   ansible.builtin.copy:
     src: files/apt-aliases.txt
     dest: ~/.dotfiles/aliases_package_manager
     mode: "640"
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts['os_family'] == 'Debian'
 
 - name: Copy Package Manager Aliases File
   ansible.builtin.copy:
     src: files/pacman-aliases.txt
     dest: ~/.dotfiles/aliases_package_manager
     mode: "640"
-  when: ansible_os_family == 'Archlinux'
+  when: ansible_facts['os_family'] == 'Archlinux'
 
 - name: Copy Package Manager Aliases File
   ansible.builtin.copy:
     src: files/zypper-aliases.txt
     dest: ~/.dotfiles/aliases_package_manager
     mode: "640"
-  when: ansible_os_family == 'Suse'
+  when: ansible_facts['os_family'] == 'Suse'
 
 - name: Make Symlink for Package Manager Aliases File
   ansible.builtin.file:

--- a/roles/firefox/defaults/main.yml
+++ b/roles/firefox/defaults/main.yml
@@ -7,7 +7,7 @@
 # Recent Firefox versions relocate the shared root to ~/.config/mozilla/firefox
 # on machines without an existing ~/.mozilla, which is another reason to pass an
 # explicit path instead of a profile name.
-firefox_profile_root: "{{ ansible_env.HOME }}/.local/share/firefox-profiles"
+firefox_profile_root: "{{ ansible_facts['env'].HOME }}/.local/share/firefox-profiles"
 
 # The names download.mozilla.org uses for the Linux builds it ships. Mozilla
 # publishes these channels for x86_64 and arm64 only, so an unknown

--- a/roles/firefox/tasks/main.yml
+++ b/roles/firefox/tasks/main.yml
@@ -22,7 +22,7 @@
 
 - name: Download Firefox
   ansible.builtin.get_url:
-    url: "https://download.mozilla.org/?product={{ item.product }}&os={{ firefox_download_os[ansible_architecture] }}&lang=en-US"
+    url: "https://download.mozilla.org/?product={{ item.product }}&os={{ firefox_download_os[ansible_facts['architecture']] }}&lang=en-US"
     dest: "/tmp/firefox-{{ item.id }}-latest.tar.xz"
     mode: "0644"
   loop: "{{ firefox_channels }}"

--- a/roles/flatpak/tasks/main.yml
+++ b/roles/flatpak/tasks/main.yml
@@ -7,4 +7,4 @@
     # Can't run in containers
     - notest
     - flatpak
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/greenleader.codium/tasks/main.yml
+++ b/roles/greenleader.codium/tasks/main.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: Sion Fandrick
+# SPDX-FileCopyrightText: Florian Wilhelm
 # SPDX-License-Identifier: MIT
 
 ---
@@ -9,7 +10,7 @@
     key: https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.gpg
     fingerprint: "{{ gpg_fingerprint }}"
   when:
-    - ansible_os_family == 'RedHat'
+    - ansible_facts['os_family'] == 'RedHat'
 
 # rpm_key on Tumbleweed (ansible-core 2.21) fails with 'Unable to parse PGP
 # key armor' on keys that rpm itself imports fine, so import directly
@@ -19,12 +20,12 @@
   changed_when: false
   failed_when: false
   when:
-    - ansible_os_family == 'Suse'
+    - ansible_facts['os_family'] == 'Suse'
 
 - name: Ensure GPG key for repo is installed (Suse)
   ansible.builtin.command: rpm --import https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.gpg
   when:
-    - ansible_os_family == 'Suse'
+    - ansible_facts['os_family'] == 'Suse'
     - codium_gpg_key_check.rc != 0
 
 - name: Ensure repo is installed (RedHat)
@@ -38,7 +39,7 @@
     repo_gpgcheck: true
     state: present
   when:
-    - ansible_os_family == 'RedHat'
+    - ansible_facts['os_family'] == 'RedHat'
 
 - name: Ensure repo is installed (Debian)
   ansible.builtin.deb822_repository:
@@ -51,7 +52,7 @@
     state: present
     enabled: true
   when:
-    - ansible_os_family == 'Debian'
+    - ansible_facts['os_family'] == 'Debian'
 
 - name: Add VSCodium repo file
   ansible.builtin.copy:
@@ -69,7 +70,7 @@
     group: root
     mode: '0644'
   when:
-    - ansible_os_family == 'Suse'
+    - ansible_facts['os_family'] == 'Suse'
 
 - name: Ensure codium is installed
   ansible.builtin.package:

--- a/roles/iesplin.vscode/tasks/main.yml
+++ b/roles/iesplin.vscode/tasks/main.yml
@@ -1,17 +1,18 @@
 # SPDX-FileCopyrightText: iesplin
+# SPDX-FileCopyrightText: Florian Wilhelm
 # SPDX-License-Identifier: MIT
 
 ---
 # tasks file for ansible-role-vscode
 
 - ansible.builtin.include_tasks: setup-debian-repo.yml
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts['os_family'] == 'Debian'
 
 - ansible.builtin.include_tasks: setup-redhat-repo.yml
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts['os_family'] == 'RedHat'
 
 - ansible.builtin.include_tasks: setup-suse-repo.yml
-  when: ansible_os_family == 'Suse'
+  when: ansible_facts['os_family'] == 'Suse'
 
 - name: Install Visual Studio Code
   package:

--- a/roles/rpm-fusion/tasks/fedora.yml
+++ b/roles/rpm-fusion/tasks/fedora.yml
@@ -10,9 +10,9 @@
     name: "{{ item }}"
     disable_gpg_check: true
   loop:
-    - https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-{{ ansible_distribution_major_version }}.noarch.rpm
-    - https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-{{ ansible_distribution_major_version }}.noarch.rpm
-  when: ansible_os_family == 'RedHat' and ansible_distribution == 'Fedora'
+    - https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-{{ ansible_facts['distribution_major_version'] }}.noarch.rpm
+    - https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-{{ ansible_facts['distribution_major_version'] }}.noarch.rpm
+  when: ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution'] == 'Fedora'
 
 - name: Install ffmpeg Packages
   become: true
@@ -22,4 +22,4 @@
     name: ffmpeg
     disable_gpg_check: true
     allowerasing: true
-  when: ansible_os_family == 'RedHat' and ansible_distribution == 'Fedora'
+  when: ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution'] == 'Fedora'

--- a/roles/rpm-fusion/tasks/main.yml
+++ b/roles/rpm-fusion/tasks/main.yml
@@ -4,4 +4,4 @@
 ---
 - import_tasks: fedora.yml
   tags: rpm_fusion
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/virtualization/tasks/common.yml
+++ b/roles/virtualization/tasks/common.yml
@@ -23,7 +23,7 @@
 
 - name: Download and extract Lima binary
   get_url:
-    url: "https://github.com/lima-vm/lima/releases/download/{{ lima_version }}/lima-{{ lima_version[1:] }}-{{ ansible_system | lower }}-{{ ansible_architecture | lower }}.tar.gz"
+    url: "https://github.com/lima-vm/lima/releases/download/{{ lima_version }}/lima-{{ lima_version[1:] }}-{{ ansible_facts['system'] | lower }}-{{ ansible_facts['architecture'] | lower }}.tar.gz"
     dest: "/tmp/lima-{{ lima_version }}.tar.gz"
   changed_when: false
 

--- a/roles/virtualization/tasks/main.yml
+++ b/roles/virtualization/tasks/main.yml
@@ -7,20 +7,20 @@
 
 - import_tasks: fedora.yml
   tags: virtualization
-  when: ansible_os_family == 'RedHat' and ansible_distribution == 'Fedora'
+  when: ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution'] == 'Fedora'
 
 - import_tasks: el.yml
   tags: virtualization
-  when: ansible_os_family == 'RedHat' and ansible_distribution != 'Fedora'
+  when: ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution'] != 'Fedora'
 
 - import_tasks: suse.yml
   tags: virtualization
-  when: ansible_os_family == 'Suse'
+  when: ansible_facts['os_family'] == 'Suse'
 
 - import_tasks: arch.yml
   tags: virtualization
-  when: ansible_os_family == 'Archlinux'
+  when: ansible_facts['os_family'] == 'Archlinux'
 
 - import_tasks: deb.yml
   tags: virtualization
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts['os_family'] == 'Debian'

--- a/snap.yml
+++ b/snap.yml
@@ -8,7 +8,7 @@
 
   tasks:
     - when:
-        - "ansible_os_family | lower == 'debian'"
+        - "ansible_facts['os_family'] | lower == 'debian'"
       block:
         - name: Purge Snap
           ansible.builtin.include_role:


### PR DESCRIPTION
Migrates the whole repo to `ansible_facts[...]` — 73 references in 20 files.

`INJECT_FACTS_AS_VARS` is deprecated and ansible-core 2.24 removes it, at which point every top-level `ansible_*` fact becomes an undefined variable. #160 tracks the 62 first-party references and deliberately excluded these roles, on the assumption that upstream would fix them.

## Why patch instead of waiting for upstream

Neither holds up:

| Role | Upstream migrated? | Last upstream push |
| --- | --- | --- |
| `green-leader/ansible-role-codium` | no | 2023-08 |
| `iesplin/ansible-role-vscode` | no | 2022-05 |
| `bodsch/ansible-snapd` | no | 2025-03 |

These copies are also well past being vendored snapshots — `greenleader.codium` carries 8 local commits and `iesplin.vscode` 4, and both grew Suse support that upstream does not have at all. There is no sync to wait for, and a future re-vendor would not carry any of it over.

## Changes

Two commits: the vendored roles (11 references), then all first-party playbooks and roles (62 references across 17 files). Every change is mechanical:

```diff
-    - ansible_os_family == 'RedHat'
+    - ansible_facts['os_family'] == 'RedHat'
-        snap_mounts: "{{ ansible_mounts | snap_mounts }}"
+        snap_mounts: "{{ ansible_facts['mounts'] | snap_mounts }}"
```

The single quotes are deliberate. The `ansible_facts["fact_name"]` form the deprecation warning suggests nests double quotes inside the double-quoted scalar of the `snap_mounts` assignment, which is not valid YAML. Worth keeping in mind for the remaining references in #160.

## Attribution

The copies are modified rather than shipped as-is, which the README did not say. It now does, and the three modified files carry the copyright of both the original author and the author of the modifications — the original notices are retained, as MIT and BSD-2 require.

This does leave those three files inconsistent with other vendored files that have also been modified but still carry only upstream attribution. A separate sweep could make that uniform.

`ansible_facts` already resolves under the current default, so this is backwards compatible rather than a flag day. `ansible_version` and `ansible_managed` are magic variables rather than gathered facts and keep their names, as does `min_ansible_version` in galaxy metadata — a naive grep-and-replace would have caught those too.

`CLAUDE.md` previously told contributors to match the surrounding `ansible_*` style; it now documents the new convention.

## Testing

Static checks, all clean: `reuse lint` at 119/119, every modified file parses as YAML, `--syntax-check` passes on all eight playbooks, no top-level `ansible_*` fact references remain outside the magic variables noted above, and `prettier --check` flags exactly the same pre-existing files as `main` — this adds no formatting drift.

A local Debian container run got as far as confirming the `bodsch.ansible-snapd` guard resolves correctly (`snap.yml`: `ok=12 changed=2 failed=0`, block skipped as intended, no undefined variable) before it was stopped, so it is **not** a full local pass. CI here is the authoritative check, and it covers what matters most: `desktop.yml` and `common.yml` exercise these guards across all five distro families and both architectures, and every playbook runs twice for the idempotence assertion.

Closes #160
