### PR TITLE
feat(firefox): declare the add-ons and preferences in use

### DIFF
--- a/roles/firefox/defaults/main.yml
+++ b/roles/firefox/defaults/main.yml
@@ -27,19 +27,54 @@ firefox_channels:
     product: firefox-nightly-latest-ssl
     remoting_name: firefox-nightly
 
-# Add-ons force-installed via enterprise policy, keyed by add-on ID.
-# The ID has to match the one in the XPI, otherwise Firefox rejects the install.
+# Add-ons installed via enterprise policy, keyed by add-on ID. The ID has to
+# match the one in the XPI, otherwise Firefox rejects the install. `mode` is the
+# policy's installation_mode and defaults to normal_installed, which installs the
+# add-on but still lets it be disabled or removed - the right default in a
+# nightly browser, where an add-on is a suspect whenever a page misbehaves.
+# force_installed is for the ad blocker only, which should never be off by accident.
 firefox_extensions:
-  "uBlock0@raymondhill.net": "https://addons.mozilla.org/firefox/downloads/latest/ublock-origin/latest.xpi"
+  "uBlock0@raymondhill.net":
+    url: "https://addons.mozilla.org/firefox/downloads/latest/ublock-origin/latest.xpi"
+    mode: force_installed
 
-# Preferences locked via enterprise policy (about:config shows them greyed out).
-# Firefox rejects preferences that a dedicated policy already owns, so telemetry
-# and default browser prefs are set through the policies below, not from here.
+  "sponsorBlocker@ajay.app":
+    url: "https://addons.mozilla.org/firefox/downloads/latest/sponsorblock/latest.xpi"
+
+  "jid1-KKzOGWgsW3Ao4Q@jetpack":
+    url: "https://addons.mozilla.org/firefox/downloads/latest/i-dont-care-about-cookies/latest.xpi"
+
+  "{b9db16a4-6edc-47ec-a1f4-b86292ed211d}":
+    url: "https://addons.mozilla.org/firefox/downloads/latest/video-downloadhelper/latest.xpi"
+
+  "MinYT@example.org":
+    url: "https://addons.mozilla.org/firefox/downloads/latest/youtube-suite-search-fixer/latest.xpi"
+
+# Preferences set via enterprise policy. A bare value is locked (about:config
+# shows it greyed out); the mapping form takes an explicit `status`, where
+# `default` seeds the value but leaves the toggle usable - anything with a
+# checkbox in the settings UI wants that, otherwise the checkbox is dead.
+# Firefox rejects preferences that a dedicated policy already owns, so telemetry,
+# default browser and DRM prefs are set through the policies below, not from here.
 firefox_preferences:
   browser.aboutConfig.showWarning: false
   browser.newtabpage.activity-stream.showSponsored: false
   browser.newtabpage.activity-stream.showSponsoredTopSites: false
   extensions.getAddons.showPane: false
+
+  # New tab widgets that ship enabled and are pure clutter here.
+  browser.newtabpage.activity-stream.widgets.focusTimer.enabled: false
+  browser.newtabpage.activity-stream.widgets.lists.enabled: false
+  browser.newtabpage.activity-stream.widgets.sportsWidget.enabled: false
+
+  browser.toolbars.bookmarks.visibility:
+    value: always
+    status: default
+
+  # The UI language, so the translation bar has nothing to offer.
+  browser.translations.neverTranslateLanguages:
+    value: de
+    status: default
 
 # Policies that are not plain preferences. The in-app updater is disabled
 # because /opt/firefox is root-owned and updates are driven by update-firefox.sh.
@@ -48,3 +83,17 @@ firefox_policies:
   DisableFirefoxStudies: true
   DisableTelemetry: true
   DontCheckDefaultBrowser: true
+
+  # Widevine, so streaming sites work without the per-profile prompt.
+  EncryptedMediaExtensions:
+    Enabled: true
+    Locked: true
+
+  Handlers:
+    schemes:
+      mailto:
+        action: useHelperApp
+        ask: false
+        handlers:
+          - name: Gmail
+            uriTemplate: "https://mail.google.com/mail/?extsrc=mailto&url=%s"

--- a/roles/firefox/templates/policies.json.j2
+++ b/roles/firefox/templates/policies.json.j2
@@ -6,18 +6,20 @@
     {{ key | to_json }}: {{ value | to_json }},
 {% endfor %}
     "ExtensionSettings": {
-{% for addon_id, url in firefox_extensions.items() %}
+{% for addon_id, addon in firefox_extensions.items() %}
       {{ addon_id | to_json }}: {
-        "install_url": {{ url | to_json }},
-        "installation_mode": "force_installed"
+        "install_url": {{ addon['url'] | to_json }},
+        "installation_mode": {{ addon['mode'] | default("normal_installed") | to_json }}
       }{{ "," if not loop.last else "" }}
 {% endfor %}
     },
     "Preferences": {
-{% for name, value in firefox_preferences.items() %}
+{% for name, pref in firefox_preferences.items() %}
+{# A bare value is the shorthand for a locked preference. #}
+{% set spec = pref if pref is mapping else {"value": pref} %}
       {{ name | to_json }}: {
-        "Value": {{ value | to_json }},
-        "Status": "locked"
+        "Value": {{ spec['value'] | to_json }},
+        "Status": {{ spec['status'] | default("locked") | to_json }}
       }{{ "," if not loop.last else "" }}
 {% endfor %}
     }

--- a/test/container/run-test.py
+++ b/test/container/run-test.py
@@ -9,7 +9,9 @@ import re
 import sys
 import pathlib
 import shutil
+import urllib.request
 import distro
+import yaml
 
 
 def assert_equals(first, second, message):
@@ -137,15 +139,31 @@ firefox_channels = {
 }
 
 
-def read_from_omni(omni, path):
+def read_from_archive(archive, path):
     # unzip exits 2 on the non-standard headers omni.ja uses, but still extracts
     # the file correctly, so the output is checked instead of the return code.
-    result = subprocess.run(["unzip", "-p", str(omni), path], capture_output=True)
+    result = subprocess.run(["unzip", "-p", str(archive), path], capture_output=True)
     assert_true(
         len(result.stdout) > 0,
-        f"Expected to read '{path}' from '{omni}': {result.stderr.decode('utf-8')}",
+        f"Expected to read '{path}' from '{archive}': {result.stderr.decode('utf-8')}",
     )
     return result.stdout.decode("utf-8")
+
+
+def firefox_install(channel):
+    return pathlib.Path(f"/opt/firefox/firefox-{channel}/firefox")
+
+
+def installed_policies(channel):
+    policies = firefox_install(channel) / "distribution/policies.json"
+    return json.loads(policies.read_text())["policies"]
+
+
+def firefox_role_defaults():
+    """The role's own defaults, to check the generated policies against."""
+    repository = pathlib.Path(__file__).resolve().parents[2]
+    return yaml.safe_load(
+        (repository / "roles/firefox/defaults/main.yml").read_text())
 
 
 def javascript_string_list(source, name):
@@ -167,13 +185,129 @@ def elf_machine(binary):
     return int.from_bytes(header[18:20], "little")
 
 
+def assert_preferences_are_settable(policies, source, display_name):
+    """Firefox silently drops preferences it does not allow, and only reports
+    them in about:policies, so they have to be checked up front."""
+    allowed_prefixes = javascript_string_list(source, "allowedPrefixes")
+    allowed_security_prefs = javascript_string_list(source, "allowedSecurityPrefs")
+    blocked_prefs = javascript_string_list(source, "blockedPrefs")
+
+    for preference in policies.get("Preferences", {}):
+        if preference.startswith("security."):
+            allowed = preference in allowed_security_prefs
+        else:
+            allowed = any(
+                preference.startswith(prefix) for prefix in allowed_prefixes)
+        assert_true(
+            allowed and preference not in blocked_prefs,
+            f"{display_name} refuses to set '{preference}' via the "
+            f"Preferences policy. Use the dedicated policy for it instead.")
+
+
+def assert_policy_values_are_valid(policies, schema, display_name):
+    """The enums the schema spells out, for the two policies this role fills
+    from configuration. A misspelled status or installation mode is not an
+    error to Firefox, it just drops the entry."""
+    statuses = single_pattern(schema["Preferences"])["properties"]["Status"]["enum"]
+    for preference, setting in policies.get("Preferences", {}).items():
+        assert_true(
+            setting["Status"] in statuses,
+            f"'{setting['Status']}' of '{preference}' is not a preference "
+            f"status {display_name} knows about, it accepts {statuses}.")
+
+    # The catch-all "*" entry is described separately from the per-add-on ones,
+    # and only the latter can install anything.
+    modes = single_pattern(
+        schema["ExtensionSettings"])["properties"]["installation_mode"]["enum"]
+    for addon_id, settings in policies.get("ExtensionSettings", {}).items():
+        assert_true(
+            settings["installation_mode"] in modes,
+            f"'{settings['installation_mode']}' of '{addon_id}' is not an "
+            f"installation mode {display_name} knows about, it accepts {modes}.")
+        assert_true(
+            "install_url" in settings,
+            f"'{addon_id}' has no install_url, so {display_name} has nowhere "
+            f"to install it from.")
+
+
+def single_pattern(policy_schema):
+    """The sub-schema of a policy whose keys are user-chosen names."""
+    patterns = list(policy_schema["patternProperties"].values())
+    assert_equals(
+        len(patterns), 1,
+        f"Expected exactly one pattern in {policy_schema['patternProperties']}. "
+        f"Firefox restructured the schema and this test needs to be updated.")
+    return patterns[0]
+
+
+def assert_policies_match_defaults(policies, defaults, display_name):
+    """The template takes a preference either as a bare value or as a mapping
+    that names a status, and an add-on with or without an installation mode, so
+    both spellings are checked here. A preference that silently ends up locked
+    greys out a working checkbox in the settings UI."""
+    for name, preference in defaults["firefox_preferences"].items():
+        expected = preference if isinstance(preference, dict) else {
+            "value": preference
+        }
+        assert_true(
+            name in policies["Preferences"],
+            f"'{name}' is configured for the role but missing from the "
+            f"policies of {display_name}.")
+        generated = policies["Preferences"][name]
+        assert_equals(generated["Value"], expected["value"],
+                      f"Wrong value generated for preference '{name}'.")
+        assert_equals(generated["Status"], expected.get("status", "locked"),
+                      f"Wrong status generated for preference '{name}'.")
+
+    for addon_id, addon in defaults["firefox_extensions"].items():
+        assert_true(
+            addon_id in policies["ExtensionSettings"],
+            f"'{addon_id}' is configured for the role but missing from the "
+            f"policies of {display_name}.")
+        generated = policies["ExtensionSettings"][addon_id]
+        assert_equals(generated["install_url"], addon["url"],
+                      f"Wrong install_url generated for '{addon_id}'.")
+        assert_equals(generated["installation_mode"],
+                      addon.get("mode", "normal_installed"),
+                      f"Wrong installation mode generated for '{addon_id}'.")
+
+
+def assert_addon_ids_match_their_xpi():
+    """The policy names the add-on it installs by ID, and Firefox rejects the
+    install when the XPI declares a different one. The add-on ID and the AMO
+    slug in the URL are picked independently of each other, so nothing but this
+    check keeps the pair honest - and a mismatch is invisible until a browser
+    starts up without the add-on."""
+    for addon_id, settings in installed_policies("nightly").get(
+            "ExtensionSettings", {}).items():
+        xpi = pathlib.Path(f"/tmp/{addon_id}.xpi")
+        request = urllib.request.Request(
+            settings["install_url"],
+            # addons.mozilla.org answers 403 to the default urllib agent.
+            headers={"User-Agent": "system-automation-test"})
+        with urllib.request.urlopen(request) as response:
+            xpi.write_bytes(response.read())
+
+        manifest = json.loads(read_from_archive(xpi, "manifest.json"))
+        gecko = (manifest.get("browser_specific_settings")
+                 or manifest.get("applications") or {}).get("gecko", {})
+        assert_equals(
+            gecko.get("id"), addon_id,
+            f"The add-on behind '{settings['install_url']}' calls itself "
+            f"'{gecko.get('id')}', so Firefox refuses to install it as "
+            f"'{addon_id}'. Check the slug in the URL against the ID.")
+        xpi.unlink()
+        print(f"{addon_id}: served by {settings['install_url']}")
+
+
 def assert_firefox_setup():
     home = pathlib.Path.home()
+    defaults = firefox_role_defaults()
     # https://refspecs.linuxfoundation.org/elf/gabi4+/ch4.eheader.html
     expected_machine = {"x86_64": 0x3E, "aarch64": 0xB7}[platform.machine()]
 
     for channel, display_name in firefox_channels.items():
-        install = pathlib.Path(f"/opt/firefox/firefox-{channel}/firefox")
+        install = firefox_install(channel)
 
         # Mozilla serves x86_64 unless the download URL asks for another
         # architecture, so a wrong URL yields a browser that cannot run here.
@@ -214,39 +348,29 @@ def assert_firefox_setup():
         # Validate the generated policies against the rules of the very Firefox
         # build that was just installed, so this keeps working as Firefox
         # changes which policies and preferences it accepts.
-        policies = json.loads(
-            (install / "distribution/policies.json").read_text())["policies"]
+        policies = installed_policies(channel)
         omni = install / "browser/omni.ja"
 
         schema = json.loads(
-            read_from_omni(omni, "modules/policies/policies-schema.json"))
+            read_from_archive(omni, "modules/policies/policies-schema.json"))
         for policy in policies:
             assert_true(
                 policy in schema["properties"],
                 f"'{policy}' is not a policy {display_name} knows about.")
 
-        source = read_from_omni(omni, "modules/policies/Policies.sys.mjs")
-        allowed_prefixes = javascript_string_list(source, "allowedPrefixes")
-        allowed_security_prefs = javascript_string_list(source,
-                                                        "allowedSecurityPrefs")
-        blocked_prefs = javascript_string_list(source, "blockedPrefs")
+        assert_preferences_are_settable(
+            policies,
+            read_from_archive(omni, "modules/policies/Policies.sys.mjs"),
+            display_name)
+        assert_policy_values_are_valid(policies, schema["properties"],
+                                       display_name)
+        assert_policies_match_defaults(policies, defaults, display_name)
 
-        # Firefox silently drops preferences it does not allow, and only reports
-        # them in about:policies, so they have to be checked up front.
-        for preference in policies.get("Preferences", {}):
-            if preference.startswith("security."):
-                allowed = preference in allowed_security_prefs
-            else:
-                allowed = any(
-                    preference.startswith(prefix)
-                    for prefix in allowed_prefixes)
-            assert_true(
-                allowed and preference not in blocked_prefs,
-                f"{display_name} refuses to set '{preference}' via the "
-                f"Preferences policy. Use the dedicated policy for it instead.")
-
-        print(f"{display_name}: profile, desktop entry and "
+        print(f"{display_name}: profile, desktop entry, "
+              f"{len(policies['ExtensionSettings'])} add-ons, "
+              f"{len(policies['Preferences'])} preferences and "
               f"{len(policies)} policies are valid")
 
 
 run_group(assert_firefox_setup, "Assert Firefox Setup")
+run_group(assert_addon_ids_match_their_xpi, "Assert Firefox Add-on IDs")


### PR DESCRIPTION
The nightly profile on this machine carried four add-ons and a handful of preference changes that only existed because they were clicked once, so a fresh machine came up without them. This turns them into configuration.

## Add-ons

SponsorBlock, I don't care about cookies, Video DownloadHelper and YouTube Suite Search Fixer join uBlock Origin in `firefox_extensions`, which now takes `{url, mode}` per add-on. `mode` defaults to `normal_installed`, so the add-ons stay removable — in a nightly browser an add-on is a suspect whenever a page misbehaves. Only the ad blocker keeps `force_installed`.

## Preferences

- The three new tab widgets (focus timer, lists, sports) locked off, next to the existing sponsored-content preferences.
- `browser.toolbars.bookmarks.visibility` and `browser.translations.neverTranslateLanguages` at `status: default`, so the value is seeded but the toggle still works. `firefox_preferences` accepts either a bare value (locked, as before) or a `{value, status}` mapping for this.
- Widevine via `EncryptedMediaExtensions`, not via `Preferences` — Firefox owns `media.eme.enabled` through that policy and rejects it from the preference list.
- `mailto` → Gmail through the `Handlers` policy.

Deliberately left out: the prefetching and hyperlink-auditing preferences, which look like settings but are uBlock's defaults applied through the extension API — locking them by policy would collide with the extension. The toolbar layout, which Firefox rewrites on every UI version bump and would break the idempotence check.

## Tests

`assert_firefox_setup` gains checks that would otherwise fail silently, since Firefox drops policy values it does not recognise rather than reporting them:

- The generated `policies.json` is compared against the role defaults — both preference spellings, and the installation mode default — so a preference that quietly ends up locked fails the build.
- `Status` and `installation_mode` are validated against the enums in the `policies-schema.json` of the very Firefox that was just installed.
- Each `install_url` is downloaded and the ID declared in the XPI compared with the ID in the policy. Those two are picked independently of each other; a mismatch leaves the browser starting up without the add-on and nothing in the log to say why.

`read_from_omni` became `read_from_archive` (it reads XPIs too), and the preference allow-list check moved into its own function.

Verified against the real Nightly and Dev Edition installs: all assertions pass, and each one was mutation-tested to confirm it fires — bad enum values, a dropped add-on, a `default` preference flipped to `locked`, a disallowed preference prefix, and an `install_url` serving a different add-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)