### PR TITLE
Refresh the README and fix the config.yml override

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,9 +59,13 @@ prerequisites applied before the others. Tagging is inconsistent: most roles rep
 which of the two a role uses before relying on `--tags`.
 
 **Configuration is one variable file.** `default.config.yml` holds `username` plus package
-lists and is overridden by a gitignored `config.yml` via `vars_files: - [default.config.yml,
-config.yml]` — first file found wins. `desktop.yml` currently lists only the default, so
-overrides do not reach it.
+lists, loaded via `vars_files`. Every playbook then has a `Load Configuration Overrides`
+pre-task that `include_vars` a gitignored `config.yml` through
+`query('first_found', ['config.yml'], errors='ignore')`, so the file is optional and only the
+keys it defines are overridden. `include_vars` outranks `vars_files` in precedence, and the
+pre-task is tagged `always` so overrides survive a `--tags` run. Do not fold this back into
+`vars_files: - [default.config.yml, config.yml]`: that form takes the first file that exists,
+which is always the default, so `config.yml` would never be read.
 
 **Everything must work on five package managers and two architectures.** Debian/Ubuntu,
 Fedora, EL, openSUSE and Arch, on amd64 and arm64. The two mechanisms for this:

--- a/README.adoc
+++ b/README.adoc
@@ -36,19 +36,17 @@ This project contains multiple playbooks:
 
 `default.config.yml` holds the `username` and the package lists.
 
-To change settings without editing that file, put the keys you want to override into a
-gitignored `config.yml` and pass it as extra vars, which take precedence over everything else:
+To change settings, put the keys you want to override into a file named `config.yml` next to
+it. It is gitignored and picked up automatically by every playbook, so no extra flag is
+needed:
 
+.config.yml
 ----
-ansible-playbook --ask-become-pass --inventory inventory --extra-vars "@config.yml" common.yml
+username: alice
 ----
 
-Only the keys present in `config.yml` are overridden; the rest keep their defaults.
-
-CAUTION: The playbooks also declare `vars_files: - [default.config.yml, config.yml]`, which
-reads as an override but is not one. Ansible uses the first file in such a list that exists,
-and `default.config.yml` always exists, so `config.yml` is never picked up that way. Use
-`--extra-vars` as shown above.
+Only the keys present in `config.yml` are overridden, the rest keep the values from
+`default.config.yml`. Leaving the file out entirely is fine.
 
 == Preparation
 

--- a/README.adoc
+++ b/README.adoc
@@ -14,8 +14,8 @@ ifdef::env-github[]
 :warning-caption: :warning:
 endif::[]
 
-image::https://github.com/fwilhe2/system-automation/workflows/CI/badge.svg[CI Job]
-image::https://api.reuse.software/badge/github.com/fwilhe2/system-automation[REUSE status]
+image:https://github.com/fwilhe2/system-automation/workflows/CI/badge.svg[CI Job,link=https://github.com/fwilhe2/system-automation/actions/workflows/main.yml]
+image:https://api.reuse.software/badge/github.com/fwilhe2/system-automation[REUSE status,link=https://api.reuse.software/info/github.com/fwilhe2/system-automation]
 
 A set of Ansible playbooks to setup Linux machines.
 
@@ -139,22 +139,63 @@ and defaulting to `common`:
 
 === Containerfile
 
-Containerfiles are available for testing.
-They are run automatically via the CI workflow.
+A Containerfile exists per package manager, and all of them are built and run by the CI
+workflow. They apply `epel.yml`, `snap.yml`, `common.yml` and `desktop.yml`, each one twice
+to check idempotence, and then assert properties of the resulting system
+(`test/container/run-test.py`).
 
-For running them locally, use:
+The convenient way to run one locally is `local-test-env.sh`, which builds the image and
+drops you into it. It uses `podman` when available and `docker` otherwise:
+
+----
+./local-test-env.sh fedora            # run the test suite in a fedora:devel container
+./local-test-env.sh fedora bash       # ... with a shell instead of the test runner
+----
+
+Inside an interactive container, `python3 test/container/run-playbook.py <name>` applies a
+single playbook without the assertions.
+
+To build the images by hand, note that the `VERSION` build argument is not uniform:
+
+[cols="1,2,3"]
+|===
+| Containerfile | `VERSION` is | Example
+
+| `Containerfile.dpkg`
+| a full image reference
+| `debian:testing`, `ubuntu:rolling`
+
+| `Containerfile.el`
+| a full image reference
+| `almalinux:10`
+
+| `Containerfile.fedora`
+| a bare tag, the image name is fixed
+| `latest`, `devel`
+
+| `Containerfile.opensuse`
+| a tag below `registry.opensuse.org/opensuse/`
+| `tumbleweed`, `leap:16.0`
+
+| `Containerfile.archlinux`
+| unused, the image is always `archlinux`
+| --
+|===
 
 .Test on Debian
 ----
-docker build --build-arg=VERSION=debian:testing -t system-automation-test-debian-latest --file test/container/Containerfile.dpkg .
-docker run --tty --volume $PWD:/mnt system-automation-test-debian-latest
+docker build --build-arg=VERSION=debian:testing -t system-automation-test-debian --file test/container/Containerfile.dpkg .
+docker run --tty --volume $PWD:/mnt system-automation-test-debian
 ----
 
 .Test on Fedora
 ----
-docker build --build-arg=VERSION=latest -t system-automation-test-fedora-latest --file test/container/Containerfile.fedora .
-docker run --tty --volume $PWD:/mnt system-automation-test-fedora-latest
+docker build --build-arg=VERSION=latest -t system-automation-test-fedora --file test/container/Containerfile.fedora .
+docker run --tty --volume $PWD:/mnt system-automation-test-fedora
 ----
+
+NOTE: `Containerfile.archlinux` applies `common.yml` directly instead of running
+`run-test.py`, so the Arch job checks that the playbook succeeds but not the assertions.
 
 === Lima
 
@@ -178,6 +219,17 @@ limactl shell lima_debian
 # remove the vms when you're done
 limactl delete -f lima_fedora lima_debian
 ----
+
+The vm definitions pin the image location and its digest, so they go stale when a new
+release is published. `lima_fedora_update.py` refreshes those fields in `lima_fedora.yaml`.
+
+The `CI with Lima VM` workflow runs the same thing on GitHub Actions, but only when
+triggered manually via `workflow_dispatch`.
+
+=== Debugging
+
+`debug/` holds a small node-based setup for reproducing playbook failures locally;
+see `debug/README.md`.
 
 == License
 

--- a/README.adoc
+++ b/README.adoc
@@ -30,22 +30,41 @@ This project contains multiple playbooks:
 * `desktop.yml`: Setup for desktop computers
 * `vm-host.yml`: Skips development tools, meant for hosts running https://github.com/fwilhe2/dev[dev]
 * `dev-env.yml`: Skips virtualization tools, meant for guests running https://github.com/fwilhe2/dev[dev]
+* `clone-git-repos.yml`: Clones the author's git repositories into `~/code`
+
+== Configuration
+
+`default.config.yml` holds the `username` and the package lists.
+
+To change settings without editing that file, put the keys you want to override into a
+gitignored `config.yml` and pass it as extra vars, which take precedence over everything else:
+
+----
+ansible-playbook --ask-become-pass --inventory inventory --extra-vars "@config.yml" common.yml
+----
+
+Only the keys present in `config.yml` are overridden; the rest keep their defaults.
+
+CAUTION: The playbooks also declare `vars_files: - [default.config.yml, config.yml]`, which
+reads as an override but is not one. Ansible uses the first file in such a list that exists,
+and `default.config.yml` always exists, so `config.yml` is never picked up that way. Use
+`--extra-vars` as shown above.
 
 == Preparation
 
 .Preparation for Fedora
 ----
-sudo dnf install -y ansible curl bash unzip
+sudo dnf install -y git ansible curl bash unzip
 ----
 
 .Preparation for *EL-like
 ----
-sudo dnf install -y ansible-core curl bash unzip
+sudo dnf install -y git ansible-core curl bash unzip
 ----
 
 .Preparation for Ubuntu/Debian
 ----
-sudo apt -y install ansible curl bash unzip
+sudo apt -y install git ansible curl bash unzip
 ----
 
 .Preparation for opensuse
@@ -74,6 +93,30 @@ This requires `ansible`, `curl`, `bash` and `unzip`.
 
 == Setup (traditional)
 
+.Get the sources
+----
+git clone https://github.com/fwilhe2/system-automation.git
+cd system-automation
+----
+
+.Install the collections the roles depend on
+----
+ansible-galaxy install -r requirements.yml
+----
+
+IMPORTANT: This step is not optional. Several roles use modules from `community.general`,
+and the first one of them runs early in the `common` playbook.
+
+.Enable EPEL (*EL-like only) and remove snap (Debian/Ubuntu only)
+----
+ansible-playbook --ask-become-pass --inventory inventory epel.yml
+ansible-playbook --ask-become-pass --inventory inventory snap.yml
+----
+
+Both playbooks are no-ops on distributions they do not apply to, so running them
+unconditionally is safe. On *EL-like systems `epel.yml` has to run before `common.yml`,
+otherwise packages from EPEL are missing.
+
 .Run `common` playbook
 ----
 ansible-playbook --ask-become-pass --inventory inventory common.yml
@@ -82,6 +125,14 @@ ansible-playbook --ask-become-pass --inventory inventory common.yml
 .Run `desktop` playbook
 ----
 ansible-playbook --ask-become-pass --inventory inventory desktop.yml
+----
+
+`run.sh` wraps the same command, taking the playbook name without the `.yml` suffix
+and defaulting to `common`:
+
+----
+./run.sh
+./run.sh desktop
 ----
 
 == Testing

--- a/common.yml
+++ b/common.yml
@@ -6,7 +6,13 @@
   hosts: all
 
   vars_files:
-    - [default.config.yml, config.yml]
+    - default.config.yml
+
+  pre_tasks:
+    - name: Load Configuration Overrides
+      ansible.builtin.include_vars: "{{ item }}"
+      loop: "{{ query('ansible.builtin.first_found', ['config.yml'], errors='ignore') }}"
+      tags: always
 
   roles:
     - basic

--- a/desktop.yml
+++ b/desktop.yml
@@ -8,6 +8,12 @@
   vars_files:
     - default.config.yml
 
+  pre_tasks:
+    - name: Load Configuration Overrides
+      ansible.builtin.include_vars: "{{ item }}"
+      loop: "{{ query('ansible.builtin.first_found', ['config.yml'], errors='ignore') }}"
+      tags: always
+
   roles:
     # Skipped where Microsoft's repo signing fails modern OpenPGP verifiers:
     # Tumbleweed's rpm rejects the key armor, and the stale arm64 'code'

--- a/dev-env.yml
+++ b/dev-env.yml
@@ -6,7 +6,13 @@
   hosts: all
 
   vars_files:
-    - [default.config.yml, config.yml]
+    - default.config.yml
+
+  pre_tasks:
+    - name: Load Configuration Overrides
+      ansible.builtin.include_vars: "{{ item }}"
+      loop: "{{ query('ansible.builtin.first_found', ['config.yml'], errors='ignore') }}"
+      tags: always
 
   roles:
     - basic

--- a/minimal.yml
+++ b/minimal.yml
@@ -6,7 +6,13 @@
   hosts: all
 
   vars_files:
-    - [default.config.yml, config.yml]
+    - default.config.yml
+
+  pre_tasks:
+    - name: Load Configuration Overrides
+      ansible.builtin.include_vars: "{{ item }}"
+      loop: "{{ query('ansible.builtin.first_found', ['config.yml'], errors='ignore') }}"
+      tags: always
 
   roles:
     - basic

--- a/vm-host.yml
+++ b/vm-host.yml
@@ -6,7 +6,13 @@
   hosts: all
 
   vars_files:
-    - [default.config.yml, config.yml]
+    - default.config.yml
+
+  pre_tasks:
+    - name: Load Configuration Overrides
+      ansible.builtin.include_vars: "{{ item }}"
+      loop: "{{ query('ansible.builtin.first_found', ['config.yml'], errors='ignore') }}"
+      tags: always
 
   roles:
     - basic


### PR DESCRIPTION
Started as a review of `README.adoc` against the actual repo state. Two of the findings were
documentation drift, the third turned out to be a real bug.

## docs: fix the documented setup path

The traditional setup instructions could not be followed end to end:

- No `ansible-galaxy install -r requirements.yml` step, although `basic`, `development` and
  `flatpak` use `community.general` modules and the first of them runs at the start of
  `common.yml`. `bootstrap.sh` and `test/container/run-test.py` both install the collections;
  only the README did not mention it.
- No step to obtain the sources at all, and `git` was missing from the Fedora, *EL and Debian
  preparation lines while openSUSE and Arch already listed it.
- `epel.yml` and `snap.yml` were listed under Project Layout but never placed in the setup
  order, even though EPEL has to be enabled before `common.yml` on *EL.

Also documents `clone-git-repos.yml` and the `run.sh` wrapper.

## docs: bring the testing section up to date

Two of the five Containerfiles were documented, and their build arguments were shown without
noting that `VERSION` means something different in each one, so extrapolating from the two
examples gets the other three wrong. Adds a table covering all five, documents
`local-test-env.sh`, notes that the Arch image applies `common.yml` directly rather than
running the assertions, mentions `lima_fedora_update.py` and that the Lima workflow is
`workflow_dispatch` only, points at `debug/`, and makes the badges link through.

## fix: make the config.yml override actually work

`vars_files: - [default.config.yml, config.yml]` reads as an override but is not one. Ansible
treats a nested list as alternatives and takes the first file that exists; `default.config.yml`
always exists, so `config.yml` was never loaded by any playbook.

Reversing the order would not fix it either, because the alternatives form picks one file
instead of merging: a `config.yml` overriding a single key would leave `basic_packages` and
the other lists undefined and fail the run.

Instead, `default.config.yml` is loaded via `vars_files` and a pre-task includes `config.yml`
when it exists. `include_vars` outranks `vars_files`, so only the keys present in `config.yml`
are overridden; `first_found` with `errors='ignore'` keeps the file optional; `tags: always`
means overrides still apply to a `--tags` run. `desktop.yml`, which previously read only
`default.config.yml`, gets the same pre-task, so overrides now reach the desktop packages and
codium extensions.

## Verification

- Variable resolution checked against the real `common.yml` stack with a temporary probe
  playbook: with a `config.yml` setting only `username`, it resolved to the override while
  `basic_packages` stayed defined from the defaults; without the file, `username` fell back to
  the default.
- All eight playbooks pass `--syntax-check`, `ansible-lint` passes at the production profile,
  `prettier --check` clean, `reuse lint` compliant, `asciidoctor` renders the README.

Not addressed here: every container job in `main.yml` passes `--env GITHUB_TOKEN`, but nothing
under `test/container/` or in the roles reads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)