### PR TITLE
Add a --uvx mode so the host needs no ansible install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ debug/node_modules
 __pycache__
 # Scratch directory ansible-lint creates for the collections it resolves
 .ansible
+# Collections `run.sh --uvx` resolves, kept out of ~/.ansible/collections
+.ansible-deps
 

--- a/run.sh
+++ b/run.sh
@@ -6,7 +6,38 @@
 set -o nounset
 set -o errexit
 
+# With --uvx, ansible-core is supplied by an ephemeral uv environment instead of
+# being installed on the host, and the collections from requirements.yml go to a
+# gitignored directory in the repo rather than to ~/.ansible/collections. Python
+# is still required on the host either way: that is how ansible modules execute.
+UVX=false
+if [ "${1:-}" = "--uvx" ]; then
+  UVX=true
+  shift
+fi
+
 # Common playbook is default
 PLAYBOOK="${1:-common}"
 
-ansible-playbook --ask-become-pass --inventory inventory $PLAYBOOK.yml
+if [ "$UVX" = true ]; then
+  # Pinned rather than floating, so a release cannot change what runs against
+  # the machine mid-session. Bump deliberately.
+  ANSIBLE_CORE_VERSION="2.21.2"
+  COLLECTIONS_PATH="$PWD/.ansible-deps/collections"
+
+  # Only on the first run; delete .ansible-deps to force a refresh.
+  # ANSIBLE_COLLECTIONS_PATH has to be set for the install too, not just the
+  # playbook: otherwise ansible-galaxy sees a copy in ~/.ansible/collections,
+  # decides there is nothing to do and leaves the target directory empty.
+  if [ ! -d "$COLLECTIONS_PATH/ansible_collections/community/general" ]; then
+    ANSIBLE_COLLECTIONS_PATH="$COLLECTIONS_PATH" \
+      uvx --from "ansible-core==$ANSIBLE_CORE_VERSION" \
+      ansible-galaxy collection install -r requirements.yml -p "$COLLECTIONS_PATH"
+  fi
+
+  ANSIBLE_COLLECTIONS_PATH="$COLLECTIONS_PATH" \
+    uvx --from "ansible-core==$ANSIBLE_CORE_VERSION" \
+    ansible-playbook --ask-become-pass --inventory inventory "$PLAYBOOK.yml"
+else
+  ansible-playbook --ask-become-pass --inventory inventory $PLAYBOOK.yml
+fi


### PR DESCRIPTION
Adds an optional `--uvx` mode to `run.sh` so a machine can be configured without
ansible installed on it.

```bash
./run.sh --uvx desktop     # ansible-core from an ephemeral uv env
./run.sh desktop           # unchanged, uses the host's ansible-playbook
```

ansible-core comes from uv, and the collections from `requirements.yml` resolve
into a gitignored `.ansible-deps/` rather than `~/.ansible/collections`. Python
is still required on the host, since that is how ansible modules execute.

Explored in #176, which also covers the container option this replaces. The
container would additionally remove Python, but needs either a privileged
container or sshd on the laptop, and has a bootstrap problem: installing docker
is one of the things this repo does.

## The non-obvious bit

`ansible-galaxy collection install -p <path>` does not isolate on its own. It
still consults the configured search path, so an existing
`~/.ansible/collections` copy of `community.general` makes it report nothing to
do and leave the target directory **empty** — after which the playbook run points
at an empty path and every collection module fails to resolve. This hit during
implementation; `ANSIBLE_COLLECTIONS_PATH` is now set for the install step too,
with a comment so it does not get tidied away later.

The ansible-core version is pinned rather than floating, so a release cannot
change what runs against a laptop mid-session. Floating is still worth having for
catching the 2.24 removal of top-level `ansible_*` variables early, but that
belongs in CI rather than in the script that configures a machine.

## Testing

Verified on a real machine:

- All eight playbooks syntax-check under the uvx interpreter, which picks up the
  repo's `ansible.cfg`.
- Cold run installs the collections into `.ansible-deps`; warm run skips the
  install and adds ~2.4s of overhead. ~30 MB on disk.
- `community.general.alternatives` resolved and executed from the repo-local
  path, so collection modules work and not just the syntax check.
- The repo's own `library/codium-extensions` module is found.
- End-to-end run of the `directories` role against localhost, idempotent at
  `changed=0`.
- `bash -n` clean, `reuse lint` compliant.

Not tested: a `become` task, which needs an interactive sudo password. Low risk,
as `become` is ansible-core behaviour and is unaffected by how ansible reached the
machine — but it is untested rather than verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
