### PR TITLE
fix: make local-test-env.sh usable for debian as well as fedora

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Florian Wilhelm
+# SPDX-License-Identifier: MIT
+
+# The Containerfiles `COPY . /home/user` as root, so anything the build context
+# carries in ends up root-owned and unwritable for the `user` the tests run as.
+# CI builds from a fresh checkout, but a local build otherwise picks up the
+# scratch directories of previous runs -- a root-owned `.ansible` in particular
+# makes every ansible-playbook call fail before it starts.
+# Keep this in sync with .gitignore.
+.ansible
+.ansible-deps
+__pycache__
+.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,15 +35,23 @@ npx prettier --check "./**/*.yml"
 then asserts properties of the resulting system. A "single test" is one distro image.
 
 ```bash
-./local-test-env.sh fedora           # interactive fedora:devel container
+# local-test-env.sh takes distro[:version] and maps it onto the Containerfile and the
+# VERSION build argument, which is not uniform: dpkg and el take a full image ref,
+# fedora only the tag, opensuse the openSUSE registry path, archlinux takes none.
+# The version defaults to the first one the CI matrix lists for that distro.
+./local-test-env.sh                  # fedora:latest, full suite
+./local-test-env.sh debian:unstable
 ./local-test-env.sh fedora bash      # ...with a shell instead of the test runner
 
-# Other distros: the VERSION arg is not uniform across Containerfiles.
-# dpkg and el take a full image ref, fedora takes only the tag, opensuse takes the
-# openSUSE registry path, archlinux takes none.
+# By hand, which is what CI does:
 docker build --build-arg=VERSION=debian:testing -t sa-deb --file test/container/Containerfile.dpkg .
 docker run --user user --tty --volume $PWD:/mnt sa-deb
 ```
+
+Two things make a local run differ from CI, both handled by `local-test-env.sh`: podman
+needs `--env SYSTEMD_OFFLINE=1` or the docker role fails on the missing init system, and
+`.dockerignore` keeps local scratch directories (`.ansible` above all) out of the build
+context, where `COPY . /home/user` would land them root-owned and break every playbook run.
 
 Inside an interactive container, `python3 test/container/run-playbook.py <name>` applies one
 playbook without the assertions.

--- a/README.adoc
+++ b/README.adoc
@@ -104,11 +104,16 @@ to check idempotence, and then assert properties of the resulting system
 (`test/container/run-test.py`).
 
 The convenient way to run one locally is `local-test-env.sh`, which builds the image and
-drops you into it. It uses `podman` when available and `docker` otherwise:
+drops you into it. It takes `distro[:version]` and translates that into the right
+Containerfile and `VERSION` build argument; the version defaults to the first one the CI
+matrix lists for that distro. It uses `podman` when available and `docker` otherwise:
 
 ----
-./local-test-env.sh fedora            # run the test suite in a fedora:devel container
-./local-test-env.sh fedora bash       # ... with a shell instead of the test runner
+./local-test-env.sh                     # fedora:latest, the full test suite
+./local-test-env.sh debian              # debian:testing
+./local-test-env.sh debian:unstable
+./local-test-env.sh fedora:rawhide bash # ... with a shell instead of the test runner
+./local-test-env.sh --help              # the distros and versions on offer
 ----
 
 Inside an interactive container, `python3 test/container/run-playbook.py <name>` applies a
@@ -130,7 +135,7 @@ To build the images by hand, note that the `VERSION` build argument is not unifo
 
 | `Containerfile.fedora`
 | a bare tag, the image name is fixed
-| `latest`, `devel`
+| `latest`, `rawhide`
 
 | `Containerfile.opensuse`
 | a tag below `registry.opensuse.org/opensuse/`
@@ -141,14 +146,25 @@ To build the images by hand, note that the `VERSION` build argument is not unifo
 | --
 |===
 
-.For example, on Debian
+.Test on Debian
 ----
 docker build --build-arg=VERSION=debian:testing -t system-automation-test-debian --file test/container/Containerfile.dpkg .
 docker run --tty --volume $PWD:/mnt system-automation-test-debian
 ----
 
+.Test on Fedora
+----
+docker build --build-arg=VERSION=latest -t system-automation-test-fedora --file test/container/Containerfile.fedora .
+docker run --tty --volume $PWD:/mnt system-automation-test-fedora
+----
+
 NOTE: `Containerfile.archlinux` applies `common.yml` directly instead of running
 `run-test.py`, so the Arch job checks that the playbook succeeds but not the assertions.
+
+NOTE: When running an image with `podman` by hand, add `--env SYSTEMD_OFFLINE=1`, which is
+what `local-test-env.sh` does. None of the images run systemd, and ansible's systemd module
+only notices that by itself under docker; under podman the docker role fails with "Service
+is in unknown state".
 
 === Lima
 

--- a/local-test-env.sh
+++ b/local-test-env.sh
@@ -5,21 +5,95 @@
 
 set -o nounset
 set -o errexit
-set -x
 
-DISTRO=fedora
-if [[ "$#" -ge 1 ]]; then
-    DISTRO=$1
+usage() {
+    cat <<'EOF'
+Usage: ./local-test-env.sh [DISTRO[:VERSION]] [ENTRYPOINT]
+
+Builds the test image for DISTRO and runs the test suite in it.
+
+DISTRO defaults to fedora. VERSION defaults to the first value listed below,
+and takes the same values as the CI matrix in .github/workflows/main.yml:
+
+  debian      stable, testing, unstable
+  ubuntu      latest, rolling, devel
+  fedora      latest, rawhide
+  el          almalinux:10
+  opensuse    tumbleweed, leap:16.0
+  archlinux   -- (the image is always archlinux:latest)
+
+ENTRYPOINT replaces the test runner, e.g. bash for an interactive shell.
+
+Examples:
+  ./local-test-env.sh                   # fedora:latest, full test suite
+  ./local-test-env.sh debian:unstable
+  ./local-test-env.sh fedora:rawhide bash
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
 fi
 
-ENTRYPOINT=''
+SPEC=${1:-fedora}
+DISTRO=${SPEC%%:*}
+VERSION=''
+if [[ "$SPEC" == *:* ]]; then
+    VERSION=${SPEC#*:}
+fi
+
+# The VERSION build argument is not uniform across the Containerfiles: dpkg and
+# el take a full image reference, fedora a bare tag, opensuse a path below
+# registry.opensuse.org/opensuse/, and archlinux takes none at all.
+case "$DISTRO" in
+    debian | ubuntu)
+        CONTAINERFILE=Containerfile.dpkg
+        case "$DISTRO" in
+            debian) BUILD_ARGS=(--build-arg="VERSION=debian:${VERSION:-testing}") ;;
+            ubuntu) BUILD_ARGS=(--build-arg="VERSION=ubuntu:${VERSION:-latest}") ;;
+        esac
+        ;;
+    fedora)
+        CONTAINERFILE=Containerfile.fedora
+        BUILD_ARGS=(--build-arg="VERSION=${VERSION:-latest}")
+        ;;
+    el)
+        CONTAINERFILE=Containerfile.el
+        BUILD_ARGS=(--build-arg="VERSION=${VERSION:-almalinux:10}")
+        ;;
+    opensuse)
+        CONTAINERFILE=Containerfile.opensuse
+        BUILD_ARGS=(--build-arg="VERSION=${VERSION:-tumbleweed}")
+        ;;
+    archlinux)
+        CONTAINERFILE=Containerfile.archlinux
+        BUILD_ARGS=()
+        ;;
+    *)
+        echo "Unknown distro: $DISTRO" >&2
+        usage >&2
+        exit 1
+        ;;
+esac
+
+ENTRYPOINT=()
 if [[ "$#" -ge 2 ]]; then
-    ENTRYPOINT="--entrypoint=$2"
+    ENTRYPOINT=("--entrypoint=$2")
 fi
+
+# Image tags may not contain a colon, which el and opensuse versions do.
+TAG="system-automation-$DISTRO${VERSION:+-${VERSION//[^a-zA-Z0-9_.-]/-}}"
 
 CLI=docker
-
 command -v podman >/dev/null 2>&1 && CLI=podman
 
-$CLI build --build-arg=VERSION=devel -t system-automation-$DISTRO --file test/container/Containerfile.$DISTRO .
-$CLI run -it --rm --volume $PWD:/mnt $ENTRYPOINT --privileged system-automation-$DISTRO
+# None of the images run systemd as pid 1. Under docker, which is what CI uses,
+# ansible's systemd module notices that on its own and skips the unit handling
+# with a warning. Under podman it does not -- is_chroot() compares / against
+# /proc/1/root, which match there -- so it runs systemctl for real and the
+# docker role fails with "Service is in unknown state". SYSTEMD_OFFLINE puts
+# both runtimes on the same path the CI jobs take.
+set -x
+$CLI build "${BUILD_ARGS[@]+"${BUILD_ARGS[@]}"}" -t "$TAG" --file "test/container/$CONTAINERFILE" .
+$CLI run -it --rm --volume "$PWD:/mnt" --env SYSTEMD_OFFLINE=1 "${ENTRYPOINT[@]+"${ENTRYPOINT[@]}"}" --privileged "$TAG"

--- a/test/container/Containerfile.opensuse
+++ b/test/container/Containerfile.opensuse
@@ -7,9 +7,25 @@ FROM registry.opensuse.org/opensuse/$VERSION
 
 ENV TERM=xterm
 
+# codecs.opensuse.org holds nothing this image needs and is regularly
+# unreachable, and a single skipped repository is enough to make zypper exit
+# 106 even when every package installed. The alias differs between Tumbleweed
+# and Leap, so name both: zypper warns about the one that is not there and
+# still succeeds.
+RUN zypper --non-interactive removerepo repo-openh264 openSUSE:repo-openh264
+
+# download.opensuse.org hands out mirrors that intermittently 404 or refuse the
+# connection, which failed whole CI runs for no reason of ours, so retry before
+# giving up.
 # gawk is listed explicitly so zypper does not pick busybox-gawk as dependency
 # provider, which conflicts with the devel_basis pattern installed later
-RUN zypper --non-interactive install git ansible curl unzip bash python3-distro shadow sudo gawk \
+RUN for attempt in 1 2 3; do \
+  zypper --non-interactive refresh \
+  && zypper --non-interactive install git ansible curl unzip bash python3-distro shadow sudo gawk \
+  && break; \
+  [ "$attempt" = 3 ] && exit 1; \
+  sleep 20; \
+  done \
   && mkdir -p /home/user && echo "user:x:1001:1001:user:/home/user:/bin/bash" >> /etc/passwd \
   && chown -R user /home/user \
   && echo 'user ALL=(ALL:ALL) NOPASSWD:ALL' >> /etc/sudoers


### PR DESCRIPTION
Stacked on #178 -- that PR's commit is included here until it merges. The README
changes below build on its rewrite of the Testing section.

`local-test-env.sh` hardcoded `Containerfile.$DISTRO` and `VERSION=devel`, so it
only ever addressed the fedora image -- and not even that one, since fedora has
no `devel` tag on Docker Hub. It now takes `distro[:version]` and maps that onto
the right Containerfile and the right shape of the `VERSION` build argument (a
full image reference for dpkg and el, a bare tag for fedora, a registry path for
opensuse, nothing for archlinux), defaulting to the first version the CI matrix
lists for that distro.

Two further things kept a local run from behaving like a CI run:

- `COPY . /home/user` runs as root, so the gitignored scratch directories of
  previous local runs ended up in the image root-owned. A root-owned `.ansible`
  makes every `ansible-playbook` call fail before its first task with
  `Unable to create local directories '/home/user/.ansible/tmp'`. CI never hits
  this because it builds from a fresh checkout. A `.dockerignore` keeps those
  directories out of the build context.
- None of the images run systemd. Under docker, which is what CI uses, ansible's
  systemd module notices and skips the unit handling with a warning; under
  podman `is_chroot()` does not detect the container, so the docker role fails
  with `Service is in unknown state`. `SYSTEMD_OFFLINE=1` puts podman on the same
  path the CI jobs take.

## Testing

Both images build, and `.ansible`, `.ansible-deps` and `.claude` are absent from
them. Every argument form was checked against a stub container CLI, `reuse lint`
passes and `bash -n` is clean. The fedora suite ran through the galaxy deps,
epel, snap and the first `common.yml` pass with `failed=0`, with the docker task
behaving exactly as it does in the CI log. Neither suite reached `desktop.yml` or
the second idempotence pass locally, so the container jobs here are the real
check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)