### PR TITLE
feat(firefox): let add-ons run in private windows

### DIFF
--- a/roles/firefox/defaults/main.yml
+++ b/roles/firefox/defaults/main.yml
@@ -40,6 +40,9 @@ firefox_channels:
 # add-on but still lets it be disabled or removed - the right default in a
 # nightly browser, where an add-on is a suspect whenever a page misbehaves.
 # force_installed is for the ad blocker only, which should never be off by accident.
+# `private_browsing` is the policy's private_browsing and defaults to true, because
+# the desktop entries pass --private-window and an add-on that is not allowed there
+# is an add-on that never runs. Set it to false for one that should stay out.
 firefox_extensions:
   "uBlock0@raymondhill.net":
     url: "https://addons.mozilla.org/firefox/downloads/latest/ublock-origin/latest.xpi"

--- a/roles/firefox/templates/policies.json.j2
+++ b/roles/firefox/templates/policies.json.j2
@@ -7,9 +7,12 @@
 {% endfor %}
     "ExtensionSettings": {
 {% for addon_id, addon in firefox_extensions.items() %}
+{# Add-ons are off in private windows unless this is set, and the desktop #}
+{# entries open every window private, so without it they would never run. #}
       {{ addon_id | to_json }}: {
         "install_url": {{ addon['url'] | to_json }},
-        "installation_mode": {{ addon['mode'] | default("normal_installed") | to_json }}
+        "installation_mode": {{ addon['mode'] | default("normal_installed") | to_json }},
+        "private_browsing": {{ addon['private_browsing'] | default(true) | to_json }}
       }{{ "," if not loop.last else "" }}
 {% endfor %}
     },

--- a/test/container/assertions.py
+++ b/test/container/assertions.py
@@ -145,8 +145,16 @@ def assert_policy_values_are_valid(policies, schema, display_name):
 
     # The catch-all "*" entry is described separately from the per-add-on ones,
     # and only the latter can install anything.
-    modes = single_pattern(
-        schema["ExtensionSettings"])["properties"]["installation_mode"]["enum"]
+    addon_schema = single_pattern(schema["ExtensionSettings"])["properties"]
+    modes = addon_schema["installation_mode"]["enum"]
+    # Without this key an add-on is disabled in private windows, which is every
+    # window these channels open, so a Firefox that stopped honouring it would
+    # leave the add-ons installed but never running.
+    assert_true(
+        "private_browsing" in addon_schema,
+        f"{display_name} does not know a 'private_browsing' setting for "
+        f"add-ons any more. Check how it now allows them in private windows.")
+
     for addon_id, settings in policies.get("ExtensionSettings", {}).items():
         assert_true(
             settings["installation_mode"] in modes,
@@ -198,6 +206,9 @@ def assert_policies_match_defaults(policies, defaults, display_name):
         assert_equals(generated["installation_mode"],
                       addon.get("mode", "normal_installed"),
                       f"Wrong installation mode generated for '{addon_id}'.")
+        assert_equals(generated["private_browsing"],
+                      addon.get("private_browsing", True),
+                      f"Wrong private browsing setting generated for '{addon_id}'.")
 
 
 def assert_addon_ids_match_their_xpi():


### PR DESCRIPTION
The desktop entries for both channels pass `--private-window`, and Firefox disables add-ons in private windows unless the `ExtensionSettings` policy allows them. So every add-on the role installs was sitting there installed and never running.

- `policies.json.j2` emits `private_browsing` for each add-on, defaulting to `true`
- `defaults/main.yml` documents the optional per-add-on `private_browsing` key next to `mode`, for an add-on that should stay out of private windows
- the container assertions check the generated value against the role defaults, and fail if the installed Firefox no longer knows a `private_browsing` add-on setting — the same guard style as the existing `installation_mode` enum check

Verified: template renders valid JSON, both assertion functions pass against the current mozilla-central `policies-schema.json` (`private_browsing` is a boolean on the per-add-on pattern), prettier and ansible-lint clean. The container suite was not run locally; CI covers it.

Note for existing profiles: the policy grants the permission rather than overriding a choice already stored in the profile, so add-ons installed before this may need a one-time toggle in `about:addons`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)