### PR TITLE
feat(rust): install the toolchain with rustup

### DIFF
--- a/playbooks/common.yml
+++ b/playbooks/common.yml
@@ -36,5 +36,10 @@
       become: true
       tags: [development]
 
+    # Unprivileged on purpose: rustup installs into the user's home, and it
+    # needs the compilers and headers the development role brings in.
+    - role: rust
+      tags: [rust]
+
     - role: virtualization
       tags: [virtualization]

--- a/roles/development/defaults/main.yml
+++ b/roles/development/defaults/main.yml
@@ -4,7 +4,6 @@
 ---
 development_packages:
   Debian:
-    - cargo
     - default-jdk-headless
     - golang
     - maven
@@ -12,28 +11,23 @@ development_packages:
     - npm
     - yarnpkg
   RedHat:
-    - cargo
     - golang
     - java-25-openjdk-devel
     - maven
     - nodejs
     - npm
-    - rust
   Suse:
-    - cargo
     - go
     - java-25-openjdk-devel
     - maven
     - nodejs-default
     - npm-default
-    - rust
   Archlinux:
     - go
     - jdk-openjdk
     - maven
     - nodejs
     - npm
-    - rust
 
 # Compilers and headers, which each distribution groups differently. Keyed by
 # distribution first and os_family second, because the EL distributions do not

--- a/roles/rust/defaults/main.yml
+++ b/roles/rust/defaults/main.yml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Florian Wilhelm
+# SPDX-License-Identifier: MIT
+
+---
+# The toolchain rustup installs and, on a machine that does not have rustup
+# yet, makes the default. rustup builds the target triple from the host it runs
+# on, so this covers both architectures without naming either.
+rust_toolchain: stable
+
+# `default` is what the plain `curl https://sh.rustup.rs | sh` installs: the
+# compiler plus rustfmt, clippy and the docs. `minimal` drops everything but
+# the compiler, cargo and rust-std.
+rust_profile: default
+
+rust_installer_url: https://sh.rustup.rs
+rust_installer_path: /tmp/rustup-init.sh
+
+# Where rustup puts the toolchains and the `cargo`, `rustc` and `rustup` entry
+# points. `rust_home` is registered by the first task of the role; see the
+# comment there for why the home directory is not taken from the facts.
+rust_cargo_home: "{{ rust_home.stat.path }}/.cargo"

--- a/roles/rust/tasks/main.yml
+++ b/roles/rust/tasks/main.yml
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Florian Wilhelm
+# SPDX-License-Identifier: MIT
+
+---
+# Rust comes from rustup rather than from the distribution packages, which are
+# too old on everything but Arch and Fedora. This is the documented
+# `curl https://sh.rustup.rs | sh` install, split into a download and a run so
+# that it happens once instead of on every play.
+# rustup installs into the home directory, and the tasks below need it spelled
+# out because a command is not run through a shell. It cannot come from
+# `ansible_facts['env']`: the vendored snapd role re-gathers facts under
+# `become` on Debian, which leaves the whole play with root's environment.
+# Every module expands `~` in a path itself, in the environment of the user it
+# really runs as, so this is the reliable way to ask.
+# The quotes around the tilde are not optional: bare `~` is null in YAML.
+- name: Get the Home Directory
+  ansible.builtin.stat:
+    path: "~"
+  register: rust_home
+
+- name: Get the Installed Rustup
+  ansible.builtin.stat:
+    path: "{{ rust_cargo_home }}/bin/rustup"
+  register: rust_rustup
+
+- name: Install Rustup
+  when: not rust_rustup.stat.exists
+  block:
+    # Fetched only when it is about to be run: the script behind the URL
+    # changes with every rustup release, which get_url would report as a change
+    # on a machine that has the toolchain already.
+    - name: Download the Rustup Installer
+      ansible.builtin.get_url:
+        url: "{{ rust_installer_url }}"
+        dest: "{{ rust_installer_path }}"
+        mode: "700"
+
+    # --no-modify-path keeps the installer out of the shell startup files. It
+    # appends to `~/.bashrc`, which is a symlink into the dotfiles checkout,
+    # and a dirty checkout is a change the dotfiles role then reports on every
+    # run. The dotfiles put `~/.cargo/bin` on PATH themselves.
+    - name: Run the Rustup Installer
+      ansible.builtin.command:
+        cmd: >-
+          {{ rust_installer_path }} -y --no-modify-path
+          --default-toolchain {{ rust_toolchain }}
+          --profile {{ rust_profile }}
+        creates: "{{ rust_cargo_home }}/bin/rustup"
+
+# The installer only picks a toolchain on a machine that had no rustup, so the
+# two tasks below are what covers one that did - without touching which
+# toolchain is the default there.
+- name: Get the Installed Toolchains
+  ansible.builtin.command: "{{ rust_cargo_home }}/bin/rustup toolchain list"
+  register: rust_toolchains
+  changed_when: false
+
+# rustup names a toolchain after the host triple it is built for, so matching
+# the channel and letting rustup fill in the architecture is what makes this
+# work on both of them.
+- name: Install the Toolchain
+  ansible.builtin.command: >-
+    {{ rust_cargo_home }}/bin/rustup toolchain install {{ rust_toolchain }}
+    --profile {{ rust_profile }}
+  when: rust_toolchains.stdout_lines | select('match', rust_toolchain ~ '-') | list | length == 0
+  changed_when: true

--- a/test/container/assertions.py
+++ b/test/container/assertions.py
@@ -61,6 +61,31 @@ def assert_system_properties():
         )
 
 
+def assert_rust_toolchain():
+    """Rust comes from rustup, installed with --no-modify-path, so nothing puts
+    `~/.cargo/bin` on the PATH of this process and the binaries are called
+    through their full path here."""
+    cargo_bin = pathlib.Path.home() / ".cargo/bin"
+    for binary in ("rustup", "cargo", "rustc"):
+        executable = cargo_bin / binary
+        assert_true(os.access(executable, os.X_OK),
+                    f"Expected '{executable}' to be an executable rustup shim.")
+        assert_equals(
+            subprocess.run([str(executable), "--version"]).returncode, 0,
+            f"Expected '{executable} --version' to run with exit code 0.")
+
+    # rustup builds the toolchain name from the host triple, so a toolchain
+    # installed for the wrong architecture would show up here.
+    expected = f"stable-{platform.machine()}-unknown-linux-gnu"
+    toolchains = subprocess.run([str(cargo_bin / "rustup"), "toolchain", "list"],
+                                capture_output=True)
+    installed = toolchains.stdout.decode("utf-8")
+    assert_true(
+        any(line.startswith(expected) for line in installed.splitlines()),
+        f"Expected the '{expected}' toolchain, rustup has: {installed}")
+    print(f"rustup: {expected} installed in {cargo_bin.parent}")
+
+
 firefox_channels = {
     "devedition": "Firefox Developer",
     "nightly": "Firefox Nightly",

--- a/test/container/run-test.py
+++ b/test/container/run-test.py
@@ -98,6 +98,7 @@ def main():
 
     run_group(assertions.assert_system_properties,
               "Assert Properties of Installed System")
+    run_group(assertions.assert_rust_toolchain, "Assert Rust Toolchain")
     run_group(assertions.assert_firefox_setup, "Assert Firefox Setup")
     run_group(assertions.assert_addon_ids_match_their_xpi,
               "Assert Firefox Add-on IDs")


### PR DESCRIPTION
The distribution packages are too old on everything but Arch and Fedora, so cargo and rust are dropped from the development role and a rust role takes over with the documented `curl https://sh.rustup.rs | sh` install, split into a download and a run so it happens once instead of on every play. rustup builds the target triple from the host, which covers both architectures without naming either.

--no-modify-path keeps the installer out of the shell startup files: it appends to ~/.bashrc, which is a symlink into the dotfiles checkout, and a dirty checkout is a change the dotfiles role reports on every run. The dotfiles put ~/.cargo/bin on PATH themselves.

The home directory is resolved by letting the stat module expand `~`, not from ansible_facts['env']: the vendored snapd role re-gathers facts under become on Debian, which leaves the play with root's environment.