### PR TITLE
Disable telemetry system-wide and in Go

### DIFF
--- a/playbooks/common.yml
+++ b/playbooks/common.yml
@@ -46,3 +46,7 @@
 
     - role: gcl
       tags: [gcl]
+
+    # After the roles that install the tools it opts out of
+    - role: telemetry
+      tags: [telemetry]

--- a/roles/telemetry/tasks/main.yml
+++ b/roles/telemetry/tasks/main.yml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Florian Wilhelm
+# SPDX-License-Identifier: MIT
+
+---
+# `/etc/environment` is read by pam_env on every login on all five
+# distributions, so this reaches shells and the GNOME session alike. DO_NOT_TRACK
+# is the cross-vendor opt-out (https://consoledonottrack.com/) that a growing
+# number of CLI tools honour; setting it once beats chasing per-tool variables.
+- name: Opt out of telemetry system-wide
+  become: true
+  ansible.builtin.lineinfile:
+    path: /etc/environment
+    regexp: "^DO_NOT_TRACK="
+    line: DO_NOT_TRACK=1
+    create: true
+    mode: "644"
+
+# Go 1.23 and later collect telemetry counters locally; `off` stops the
+# collection itself rather than only the upload. This is the file `go telemetry
+# off` writes, written directly so the role stays idempotent.
+- name: Ensure the Go telemetry directory exists
+  ansible.builtin.file:
+    path: ~/.config/go/telemetry
+    state: directory
+    mode: "750"
+
+- name: Turn Go telemetry off
+  ansible.builtin.copy:
+    dest: ~/.config/go/telemetry/mode
+    content: "off\n"
+    mode: "640"

--- a/test/container/assertions.py
+++ b/test/container/assertions.py
@@ -279,6 +279,18 @@ def assert_addon_ids_match_their_xpi():
         print(f"{addon_id}: served by {settings['install_url']}")
 
 
+def assert_telemetry_opt_out():
+    assert_true(
+        "DO_NOT_TRACK=1" in pathlib.Path("/etc/environment").read_text().splitlines(),
+        "Expected DO_NOT_TRACK=1 in '/etc/environment'.")
+
+    mode = pathlib.Path.home() / ".config/go/telemetry/mode"
+    assert_equals(mode.read_text().strip(), "off",
+                  f"Expected Go telemetry to be off in '{mode}'.")
+
+    print("Telemetry opt-out is in place")
+
+
 def assert_firefox_setup():
     home = pathlib.Path.home()
     defaults = firefox_role_defaults()

--- a/test/container/run-test.py
+++ b/test/container/run-test.py
@@ -99,6 +99,7 @@ def main():
     run_group(assertions.assert_system_properties,
               "Assert Properties of Installed System")
     run_group(assertions.assert_rust_toolchain, "Assert Rust Toolchain")
+    run_group(assertions.assert_telemetry_opt_out, "Assert Telemetry Opt-Out")
     run_group(assertions.assert_firefox_setup, "Assert Firefox Setup")
     run_group(assertions.assert_addon_ids_match_their_xpi,
               "Assert Firefox Add-on IDs")


### PR DESCRIPTION
New `telemetry` role in `playbooks/common.yml` (tag `telemetry`):

- `DO_NOT_TRACK=1` in `/etc/environment` — read by pam_env on login on all five distributions, so it reaches shells and the GNOME session alike. One variable instead of chasing a per-tool list.
- `~/.config/go/telemetry/mode` = `off` — Go 1.23+ collects counters locally by default; this is the file `go telemetry off` writes, written directly so the role stays idempotent.
- `assert_telemetry_opt_out()` in the container assertions, wired into `run-test.py`.

Firefox was already covered by its `DisableTelemetry` and `DisableFirefoxStudies` policies.

VS Code's `telemetry.telemetryLevel` is **not** in this PR: `~/.config/Code/User/settings.json` is a symlink into `fwilhe2/dotfiles`, so it has to be set there.

Skipped: the flatpak Chrome `MetricsReportingEnabled` policy (metrics are opt-in there and the role is `notest`/Fedora-only), and .NET/Homebrew-style variables for tools that are not installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)