### PR TITLE
Pin the LibreOffice default currency to the Euro

### DIFF
--- a/roles/libreoffice/defaults/main.yml
+++ b/roles/libreoffice/defaults/main.yml
@@ -6,6 +6,12 @@
 # registrymodifications.xcu. ooLocale is the UI language, ooSetupSystemLocale
 # is the formatting locale (dates, numbers, currency) - kept apart so the UI
 # stays English regardless of which locale documents are formatted in.
+#
+# ooSetupCurrency is what the currency button inserts. It defaults to empty,
+# which means "whatever ooSetupSystemLocale implies", and that leaves the
+# currency free to follow a locale change; naming it pins it to the Euro. The
+# format is the ISO code, then the locale whose formatting rules apply.
 libreoffice_locale_settings:
   ooLocale: en-US
+  ooSetupCurrency: EUR-de-DE
   ooSetupSystemLocale: de-DE


### PR DESCRIPTION
The currency button in Calc inserts whatever `ooSetupCurrency` names. It ships
empty, which means "derive it from the formatting locale" - so it follows a
locale change instead of staying put. Naming it `EUR-de-DE` pins it.

One key in the libreoffice role's `libreoffice_locale_settings`; the existing
tasks and `assert_libreoffice_locale()` both loop over that dict, so nothing
else needed changing.

## Testing

- Applied `playbooks/desktop.yml --tags libreoffice` on Debian trixie: the
  property went from empty to `EUR-de-DE`, second run `changed=0`.
- `ansible-lint` (production), `prettier --check`, `--syntax-check`, `reuse lint`.
- The container assertion covers it automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)