### PR TITLE
ci(lima): pass GITHUB_TOKEN into the VM

### DIFF
--- a/.github/workflows/lima-ci.yml
+++ b/.github/workflows/lima-ci.yml
@@ -29,9 +29,14 @@ jobs:
           key: lima-${{ steps.lima-actions-setup.outputs.version }}
 
       - name: "Start an instance of ${{ matrix.distro }}"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -eux
 
           cat test/lima/${{ matrix.distro }}.yaml | limactl create --name=default -
           limactl start
-          lima ansible-playbook playbooks/common.yml
+          # The guest gets no environment from the host, so hand the token over
+          # explicitly - without it the GitHub API calls hit the anonymous rate limit.
+          set +x
+          lima env GITHUB_TOKEN="$GITHUB_TOKEN" ansible-playbook playbooks/common.yml


### PR DESCRIPTION
The Lima guest inherits no environment from the runner, so the GitHub API calls in the `virtualization` and `gcl` roles ran anonymously and hit the unauthenticated rate limit. Hand the token over with `lima env`, matching what the container jobs in `main.yml` already do.

`set +x` before the call so the trace does not print the token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)