### PR TITLE
feat(libreoffice): save spreadsheets as fods by default

### DIFF
--- a/roles/libreoffice/defaults/main.yml
+++ b/roles/libreoffice/defaults/main.yml
@@ -15,3 +15,8 @@ libreoffice_locale_settings:
   ooLocale: en-US
   ooSetupCurrency: EUR-de-DE
   ooSetupSystemLocale: de-DE
+
+# The filter new spreadsheets are saved with, held on the Calc factory node.
+# LibreOffice ships "calc8", the zipped .ods; this is the flat single-file
+# .fods variant of the same format, which version control can diff.
+libreoffice_calc_default_filter: OpenDocument Spreadsheet Flat XML

--- a/roles/libreoffice/tasks/main.yml
+++ b/roles/libreoffice/tasks/main.yml
@@ -50,3 +50,50 @@
     attribute: oor:op
     value: fuse
   loop: "{{ libreoffice_locale_settings | dict2items }}"
+
+# The save format lives on the Calc factory item, which the tasks below cannot
+# spawn the way the L10N ones spawn theirs: community.general.xml builds a
+# missing node by splitting the xpath on every '/' and quote, and this item's
+# path (see vars/main.yml) carries both inside a string literal, which leaves
+# the module cutting that literal in half. So the item is added whole when it is
+# missing, and only the property below it is left to the module's own creation.
+- name: Look for the LibreOffice Calc Factory Item
+  community.general.xml:
+    path: ~/.config/libreoffice/4/user/registrymodifications.xcu
+    xpath: "{{ libreoffice_calc_factory_xpath }}"
+    namespaces:
+      oor: http://openoffice.org/2001/registry
+    count: true
+  register: libreoffice_calc_factory
+  changed_when: false
+
+- name: Create the LibreOffice Calc Factory Item if not exists
+  community.general.xml:
+    path: ~/.config/libreoffice/4/user/registrymodifications.xcu
+    xpath: /oor:items
+    namespaces:
+      oor: http://openoffice.org/2001/registry
+    input_type: xml
+    add_children:
+      - '<item xmlns:oor="http://openoffice.org/2001/registry" oor:path="{{ libreoffice_calc_factory_path }}"/>'
+  when: libreoffice_calc_factory.count == 0
+
+# LibreOffice writes one item per property, so a profile it has run in holds
+# several with this same path; the [1] keeps the format from being written into
+# every one of them.
+- name: Set the Default Save Format for Spreadsheets
+  community.general.xml:
+    path: ~/.config/libreoffice/4/user/registrymodifications.xcu
+    xpath: "({{ libreoffice_calc_factory_xpath }})[1]/prop[@oor:name='ooSetupFactoryDefaultFilter']/value"
+    namespaces:
+      oor: http://openoffice.org/2001/registry
+    value: "{{ libreoffice_calc_default_filter }}"
+
+- name: Mark the Spreadsheet Save Format as Fused with the Defaults
+  community.general.xml:
+    path: ~/.config/libreoffice/4/user/registrymodifications.xcu
+    xpath: "({{ libreoffice_calc_factory_xpath }})[1]/prop[@oor:name='ooSetupFactoryDefaultFilter']"
+    namespaces:
+      oor: http://openoffice.org/2001/registry
+    attribute: oor:op
+    value: fuse

--- a/roles/libreoffice/vars/main.yml
+++ b/roles/libreoffice/vars/main.yml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Florian Wilhelm
+# SPDX-License-Identifier: MIT
+
+---
+# Not configuration - the address of the Calc factory item in
+# registrymodifications.xcu, which tasks/main.yml needs several times over. The
+# factories are a set node addressed through their template, so the path quotes
+# the factory itself and the xpath literal around it has to be double quoted.
+libreoffice_calc_factory_path: >-
+  /org.openoffice.Setup/Office/Factories/org.openoffice.Setup:Factory['com.sun.star.sheet.SpreadsheetDocument']
+libreoffice_calc_factory_xpath: >-
+  /oor:items/item[@oor:path="{{ libreoffice_calc_factory_path }}"]

--- a/test/container/assertions.py
+++ b/test/container/assertions.py
@@ -326,24 +326,39 @@ def assert_libreoffice_locale():
         return
 
     repository = pathlib.Path(__file__).resolve().parents[2]
-    settings = yaml.safe_load(
+    defaults = yaml.safe_load(
         (repository / "roles/libreoffice/defaults/main.yml").read_text()
-    )["libreoffice_locale_settings"]
+    )
+    settings = defaults["libreoffice_locale_settings"]
 
     registry = pathlib.Path.home() / ".config/libreoffice/4/user/registrymodifications.xcu"
     items = xml.etree.ElementTree.parse(registry).getroot()
     oor = "{http://openoffice.org/2001/registry}"
 
-    for name, expected in settings.items():
-        prop = items.find(
-            f"item[@{oor}path='/org.openoffice.Setup/L10N']/prop[@{oor}name='{name}']")
+    # The item path is matched in python rather than in the ElementPath
+    # expression: the factory paths quote the factory itself, and a quote inside
+    # a predicate literal is more than ElementPath's XPath subset can parse.
+    def assert_fused(item_path, name, expected):
+        prop = next(
+            (found
+             for item in items if item.get(f"{oor}path") == item_path
+             for found in item.findall(f"prop[@{oor}name='{name}']")), None)
         assert_not_none(prop, f"Expected a '{name}' property in '{registry}'.")
         assert_equals(prop.get(f"{oor}op"), "fuse",
                       f"Expected '{name}' in '{registry}' to be fused.")
         assert_equals(prop.findtext("value"), expected,
                       f"Expected '{name}' in '{registry}' to be '{expected}'.")
 
-    print(f"LibreOffice is set up for {settings}")
+    for name, expected in settings.items():
+        assert_fused("/org.openoffice.Setup/L10N", name, expected)
+
+    calc_filter = defaults["libreoffice_calc_default_filter"]
+    assert_fused(
+        "/org.openoffice.Setup/Office/Factories/org.openoffice.Setup:Factory"
+        "['com.sun.star.sheet.SpreadsheetDocument']",
+        "ooSetupFactoryDefaultFilter", calc_filter)
+
+    print(f"LibreOffice is set up for {settings}, saving as '{calc_filter}'")
 
 
 def assert_firefox_setup():


### PR DESCRIPTION
Pins Calc's default save format to the flat OpenDocument filter
(`ooSetupFactoryDefaultFilter` = `OpenDocument Spreadsheet Flat XML`), so new
spreadsheets land as a single diffable `.fods` file instead of the zipped
`.ods`. `libreoffice_calc_default_filter` in the role defaults takes it back to
`calc8` from `local.yml`.

The obvious two-task version does not work. `community.general.xml` creates a
missing node by splitting the xpath on every `/` and quote, and the factory
item's path carries both inside a string literal, so the module cuts that
literal in half and lxml fails with "Unfinished literal". The item is therefore
added whole when it is absent - guarded by a count, since `add_children` always
appends - and only the property below it is left to the module. The `[1]` on the
item keeps the property out of the several same-path items a profile LibreOffice
has run in accumulates.

The container assertion checks the new property alongside the locale ones; its
lookup moved out of the ElementPath expression into python, because a quote
inside a predicate literal is more than ElementTree's XPath subset can parse.

## Testing

- role applied twice to an empty profile: `changed=5`, then `changed=0`, output
  byte-identical to what LibreOffice itself writes
- role applied twice to a copy of a real profile with the property stripped:
  `changed=2`, then `changed=0`, exactly one property written
- assertion checked against a good file and both failure modes (wrong value,
  missing property)
- prettier, `ansible-lint` at the production profile, `reuse lint` and
  `ansible-playbook --syntax-check site.yml` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)